### PR TITLE
replaces OpenAPI documentation with make commands

### DIFF
--- a/apps/autointerp/README.md
+++ b/apps/autointerp/README.md
@@ -33,9 +33,6 @@ as much as possible we try to use classes/types from the `packages/python/neuron
    poetry run uvicorn server:app --host 0.0.0.0 --port 5003 --workers 1 --reload
    ```
 
-3. if you are making changes to the openapi spec (new/updated endpoints) and want to test those changes locally, generate your client and use the following command to point to the local autointerp client:
-   `poetry add --editable ../../packages/python/neuronpedia-autointerp-client`
-
 ## some docker commands for reference (outdated, needs fixing)
 
 likely we will just have these instructions in the root directory `readme` instead, and manual builds should happen the same way as we do it for `inference`.

--- a/schemas/Makefile
+++ b/schemas/Makefile
@@ -1,0 +1,128 @@
+# Makefile for OpenAPI client generation
+# Variables
+INFERENCE_SPEC = openapi/inference-server.yaml
+AUTOINTERP_SPEC = openapi/autointerp-server.yaml
+TS_OUTPUT_DIR = ../packages/typescript
+PY_OUTPUT_DIR = ../packages/python
+
+.PHONY: generate-inference-clients generate-autointerp-clients clean-inference-clients clean-autointerp-clients \
+        inference-setup-env autointerp-setup-env webapp-setup-env-inference webapp-setup-env-autointerp
+
+# Check if VERSION is provided
+check-version:
+ifndef VERSION
+	$(error VERSION is required. Please specify with VERSION=x.y.z)
+endif
+
+# Clean and generate inference clients
+generate-inference-clients: check-version clean-inference-clients
+	@echo "Generating Python inference client with version $(VERSION)..."
+	openapi-generator generate \
+		-i $(INFERENCE_SPEC) \
+		-g python \
+		-o $(PY_OUTPUT_DIR)/neuronpedia-inference-client \
+		--package-name neuronpedia_inference_client \
+		--additional-properties=packageVersion=$(VERSION)
+
+	@echo "Generating TypeScript inference client..."
+	openapi-generator generate \
+		-i $(INFERENCE_SPEC) \
+		-g typescript-fetch \
+		-o $(TS_OUTPUT_DIR)/neuronpedia-inference-client \
+		-p npmName=neuronpedia-inference-client,npmVersion=$(VERSION)
+
+# Clean and generate autointerp clients
+generate-autointerp-clients: check-version clean-autointerp-clients
+	@echo "Generating Python autointerp client with version $(VERSION)..."
+	openapi-generator generate \
+		-i $(AUTOINTERP_SPEC) \
+		-g python \
+		-o $(PY_OUTPUT_DIR)/neuronpedia-autointerp-client \
+		--package-name neuronpedia_autointerp_client \
+		--additional-properties=packageVersion=$(VERSION)
+
+	@echo "Generating TypeScript autointerp client..."
+	openapi-generator generate \
+		-i $(AUTOINTERP_SPEC) \
+		-g typescript-fetch \
+		-o $(TS_OUTPUT_DIR)/neuronpedia-autointerp-client \
+		-p npmName=neuronpedia-autointerp-client,npmVersion=$(VERSION)
+
+# Setup inference server environment
+inference-setup-env:
+	@echo "Setting up inference server environment..."
+	@cd ../apps/inference && \
+	poetry remove neuronpedia-inference-client && \
+	poetry add ../../packages/python/neuronpedia-inference-client/
+
+# Setup autointerp server environment
+autointerp-setup-env:
+	@echo "Setting up autointerp server environment..."
+	@cd ../apps/autointerp && \
+	poetry add ../../packages/python/neuronpedia-autointerp-client
+
+# Setup webapp environment for inference
+webapp-setup-env-inference:
+	@echo "Setting up webapp environment for inference client..."
+	@if ! command -v typescript &> /dev/null; then \
+		echo "Installing TypeScript globally..."; \
+		npm install -g typescript; \
+	fi
+	@cd ../apps/webapp && \
+	npm link ../../packages/typescript/neuronpedia-inference-client && \
+	npm link neuronpedia-inference-client
+
+# Setup webapp environment for autointerp
+webapp-setup-env-autointerp:
+	@echo "Setting up webapp environment for autointerp client..."
+	@if ! command -v typescript &> /dev/null; then \
+		echo "Installing TypeScript globally..."; \
+		npm install -g typescript; \
+	fi
+	@cd ../apps/webapp && \
+	npm link ../../packages/typescript/neuronpedia-autointerp-client && \
+	npm link neuronpedia-autointerp-client
+
+# Clean up inference clients
+clean-inference-clients:
+	@echo "Cleaning inference clients..."
+	rm -rf $(PY_OUTPUT_DIR)/neuronpedia-inference-client
+	rm -rf $(TS_OUTPUT_DIR)/neuronpedia-inference-client
+
+# Clean up autointerp clients
+clean-autointerp-clients:
+	@echo "Cleaning autointerp clients..."
+	rm -rf $(PY_OUTPUT_DIR)/neuronpedia-autointerp-client
+	rm -rf $(TS_OUTPUT_DIR)/neuronpedia-autointerp-client
+
+# Setup all for inference
+setup-all-inference: generate-inference-clients inference-setup-env webapp-setup-env-inference
+	@echo "All inference client environments set up successfully!"
+
+# Setup all for autointerp
+setup-all-autointerp: generate-autointerp-clients autointerp-setup-env webapp-setup-env-autointerp
+	@echo "All autointerp client environments set up successfully!"
+
+# Help
+help:
+	@echo "OpenAPI Client Generator Makefile"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  generate-inference-clients   - Generate Python and TypeScript clients for inference server"
+	@echo "  generate-autointerp-clients  - Generate Python and TypeScript clients for autointerp server"
+	@echo "  inference-setup-env          - Setup inference server environment with the new clients"
+	@echo "  autointerp-setup-env         - Setup autointerp server environment with the new clients"
+	@echo "  webapp-setup-env-inference   - Setup webapp environment with the new inference clients" 
+	@echo "  webapp-setup-env-autointerp  - Setup webapp environment with the new autointerp clients"
+	@echo "  setup-all-inference          - Do all setup steps for inference clients"
+	@echo "  setup-all-autointerp         - Do all setup steps for autointerp clients"
+	@echo "  clean-inference-clients      - Remove existing inference clients"
+	@echo "  clean-autointerp-clients     - Remove existing autointerp clients"
+	@echo ""
+	@echo "Required options:"
+	@echo "  VERSION=x.y.z                - Set the semantic version for both Python and TypeScript clients"
+	@echo ""
+	@echo "Example usage:"
+	@echo "  make generate-inference-clients VERSION=1.2.3"
+	@echo "  make setup-all-inference VERSION=1.2.3"
+	@echo "  make setup-all-autointerp VERSION=1.2.3"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,121 +13,36 @@ having openapi schemas allows us to use [openapi client generators](https://open
 
 this readme documents how to update the schemas and re-generate clients when we want to make additions or changes to the api.
 
-> ⚠️ **warning:** this is _draft_ documentation. we need to provide better examples of the entire development workflow: [TODO #3](https://github.com/hijohnnylin/neuronpedia/issues/3) - need better instructions on how to update openapi spec/client (or simplify by making it a `make` command)
-
 ## install openapi generator cli
 
-install the [openapi generator cli](https://openapi-generator.tech/docs/installation/) here.
+install the [openapi generator cli](https://openapi-generator.tech/docs/installation/#npm) here.
 
 ## making changes to the inference server
 
 here's how to create or update an endpoint in the inference server.
 
 1. spec out your new addition(s) or change(s) under [openapi/inference-server.yaml](openapi/inference-server.yaml) and the [openapi/inference](openapi/inference/) subdirectory. for example, you might create a new endpoint under [openapi/inference/paths](openapi/inference/paths/), then add that new endpoint path to the `inference-server.yaml` file
-2. delete the old inference clients
+2. run the command, replacing `BUMPED_SEMANTIC_VERSION`
    ```
-   cd schemas
-   rm -rf ../packages/python/neuronpedia-inference-client
-   rm -rf ../packages/typescript/neuronpedia-inference-client
+   make setup-all-inference VERSION=BUMPED_SEMANTIC_VERSION
    ```
-3. generate a new _python_ inference client, replacing `BUMPED_SEMANTIC_VERSION`
-   ```
-    openapi-generator-cli generate \
-    -i openapi/inference-server.yaml \
-    -g python \
-    -o ../packages/python/neuronpedia-inference-client \
-    --package-name neuronpedia_inference_client \
-    --additional-properties=packageVersion=[BUMPED_SEMANTIC_VERSION]
-   ```
-   this will generate the updated python client under `packages/python/neuronpedia-inference-client`
-4. generate a new _typescript_ inference client, ensuring that you replace `BUMPED_SEMANTIC_VERSION`
-   ```
-   openapi-generator-cli generate -i openapi/inference-server.yaml -g typescript-fetch -o ../packages/typescript/neuronpedia-inference-client -p npmName=neuronpedia-inference-client
-   ```
-   this will generate the updated python client under `packages/python/neuronpedia-inference-client`
-5. make your code changes to the inference server
-   1. point your local inference server code to use the updated local python client
-      ```
-      poetry remove neuronpedia-inference-client && poetry add ../../packages/python-inference-client/
-      ```
-      > ℹ️ **why import the _client_ into the server?** even though we aren't using the client calls (make requests, parse response, etc), we want to force the server to use the same types to ensure compatibility. it reduces the amount of potential errors as well! a simple example of this in the [utils/sae-vector endpoint](../apps/inference/neuronpedia_inference/endpoints/util/sae_vector.py): notice how we accept a `UtilSaeVectorPostRequest` and return a `UtilSaeVectorPost200Response`.
-   2. update the code under [apps/inference/neuronpedia_inference](../apps/inference/neuronpedia_inference/) for your changes. for example, if you were creating a new endpoint of `POST [host]/v1/util/action`, you would create a new `action.py` file under [apps/inference/neuronpedia_inference/util](apps/inference/neuronpedia_inference/util).
-6. make your code changes to the webapp server (if necessary)
-
-   1. ensure typescript is installed globally
-      ```
-      npm install -g typescript
-      ```
-   2. point your local webapp code to use the updated local typescript client
-
-      ```
-      cd ../apps/webapp
-
-      # first link the client globally
-      npm link ../../packages/typescript/neuronpedia-inference-client
-
-      # then point your webapp to use the globally linked local client instead of the production one
-      npm link neuronpedia-inference-client
-      ```
-
-   3. update your webapp code, starting by changing [../apps/webapp/lib/utils/inference.ts](../apps/webapp/lib/utils/inference.ts) to use the new/updated endpoints in the `neuronpedia-inference-client`
-
-7. bring up the webapp and inference server locally (see the main [readme](../README.md) for running dev instances), and test the calls between the two servers.
-8. once you're satisfied with the results, commit all your changes.
-9. [highly encouraged] make a PR to the official [neuronpedia repo](https://github.com/hijohnnylin/neuronpedia) and we'll review it ASAP!
+3. update the code under [apps/inference/neuronpedia_inference](../apps/inference/neuronpedia_inference/) for your changes. for example, if you were creating a new endpoint of `POST [host]/v1/util/action`, you would create a new `action.py` file under [apps/inference/neuronpedia_inference/util](apps/inference/neuronpedia_inference/util).
+4. update your webapp code, starting by changing [../apps/webapp/lib/utils/inference.ts](../apps/webapp/lib/utils/inference.ts) to use the new/updated endpoints in the `neuronpedia-inference-client`
+5. bring up the webapp and inference server locally (see the main [readme](../README.md) for running dev instances), and test the calls between the two servers.
+6. once you're satisfied with the results, commit all your changes.
+7. [highly encouraged] make a PR to the official [neuronpedia repo](https://github.com/hijohnnylin/neuronpedia) and we'll review it ASAP!
 
 ## making changes to the autointerp server
 
 the instructions are _mostly_ the same as [making changes to the inference server](#making-changes-to-the-inference-server), except names are changed from `neuronpedia-inference` to `neuronpedia-autointerp`, etc.
 
 1. spec out your new addition(s) or change(s) under [openapi/inference-server.yaml](openapi/autointerp-server.yaml) and the [openapi/autointerp](openapi/autointerp/) subdirectory.
-2. delete the old autointerp clients
+2. run the command, replacing `BUMPED_SEMANTIC_VERSION`
    ```
-   cd schemas
-   rm -rf ../packages/python/neuronpedia-autointerp-client
-   rm -rf ../packages/typescript/neuronpedia-autointerp-client
+   make setup-all-autointerp VERSION=BUMPED_SEMANTIC_VERSION
    ```
-3. generate a new _python_ autointerp client, replacing `BUMPED_SEMANTIC_VERSION`
-   ```
-    openapi-generator-cli generate \
-    -i openapi/autointerp-server.yaml \
-    -g python \
-    -o ../packages/python/neuronpedia-autointerp-client \
-    --package-name neuronpedia_autointerp_client \
-    --additional-properties=packageVersion=[BUMPED_SEMANTIC_VERSION]
-   ```
-   this will generate the updated python client under `packages/python/neuronpedia-autointerp-client`
-4. generate a new _typescript_ autointerp client
-   ```
-   openapi-generator-cli generate -i openapi/autointerp-server.yaml -g typescript-fetch -o ../packages/typescript/neuronpedia-autointerp-client -p npmName=neuronpedia-autointerp-client
-   ```
-   this will generate the updated typescript client under `packages/typescript/neuronpedia-autointerp-client`
-5. make your code changes to the autointerp server
-   1. point your local autointerp server code to use the updated local python client
-      ```
-      poetry remove neuronpedia-autointerp-client && poetry add ../../packages/python-autointerp-client/
-      ```
-   2. update the code under [apps/autointerp/neuronpedia_autointerp](../apps/autointerp/neuronpedia_autointerp/) for your changes.
-6. make your code changes to the webapp server (if necessary)
-
-   1. ensure typescript is installed globally
-      ```
-      npm install -g typescript
-      ```
-   2. point your local webapp code to use the updated local typescript client
-
-      ```
-      cd ../apps/webapp
-
-      # first link the client globally
-      npm link ../../packages/typescript/neuronpedia-autointerp-client
-
-      # then point your webapp to use the globally linked local client instead of the production one
-      npm link neuronpedia-autointerp-client
-      ```
-
-   3. update your webapp code, starting by changing [../apps/webapp/lib/utils/autointerp.ts](../apps/webapp/lib/utils/autointerp.ts) to use the new/updated endpoints in the `neuronpedia-autointerp-client`
-
-7. bring up the webapp and autointerp server locally (see the main [readme](../README.md) for running dev instances), and test the calls between the two servers.
-8. once you're satisfied with the results, commit all your changes.
-9. [highly encouraged] make a PR to the official [neuronpedia repo](https://github.com/hijohnnylin/neuronpedia) and we'll review it ASAP!
+3. update the code under [apps/autointerp/neuronpedia_autointerp](../apps/autointerp/neuronpedia_autointerp/) for your changes.
+4. update your webapp code, starting by changing [../apps/webapp/lib/utils/autointerp.ts](../apps/webapp/lib/utils/autointerp.ts) to use the new/updated endpoints in the `neuronpedia-autointerp-client`
+5. bring up the webapp and autointerp server locally (see the main [readme](../README.md) for running dev instances), and test the calls between the two servers.
+6. once you're satisfied with the results, commit all your changes.
+7. [highly encouraged] make a PR to the official [neuronpedia repo](https://github.com/hijohnnylin/neuronpedia) and we'll review it ASAP!


### PR DESCRIPTION
The documentation on how to change `python/neuronpedia-inference-client` and `typescript/neuronpedia-inference-client` after an inference endpoint is added/updated is outdated, and can just be a `make` command, and the same goes for `autointerp`. I tested my changes by following the documentation and debugging along the way, and compared the diffs to those from running make `setup-all-inference VERSION=2.0.0`/`setup-all-autointerp VERSION=2.0.0`. Limitation: you have to install the OpenAPI Generator either with `npm` or `brew`.

Fixes #3