### PR TITLE
dedupes get_layer_num_from_sae_id()

### DIFF
--- a/apps/inference/neuronpedia_inference/sae_manager.py
+++ b/apps/inference/neuronpedia_inference/sae_manager.py
@@ -26,12 +26,6 @@ class SAE_TYPE:
     SAELENS = "saelens-1"
 
 
-def get_layer_num_from_sae_id(sae_id: str) -> int:
-    if sae_id.isdigit():
-        return int(sae_id)
-    return int(sae_id.split("-")[0])
-
-
 class SAEManager:
     NEURONS_SOURCESET = "neurons"
 

--- a/apps/inference/neuronpedia_inference/utils.py
+++ b/apps/inference/neuronpedia_inference/utils.py
@@ -49,9 +49,3 @@ def get_device():
         device_count = torch.cuda.device_count()
 
     return device, device_count
-
-
-def get_layer_num_from_sae_id(sae_id: str) -> int:
-    if sae_id.isdigit():
-        return int(sae_id)
-    return int(sae_id.split("-")[0])


### PR DESCRIPTION
In `neuronpedia_inference`, we have three functions named `get_layer_num_from_sae_id`, with identical logic, and two are unused anyways. I tested my changes by running `make check-ci`.