### PR TITLE
dedupe code in all.py and single.py

### DIFF
--- a/apps/inference/neuronpedia_inference/endpoints/activation/all.py
+++ b/apps/inference/neuronpedia_inference/endpoints/activation/all.py
@@ -2,7 +2,6 @@ import logging
 import re
 from typing import Any
 
-import einops
 import torch
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -21,6 +20,9 @@ from neuronpedia_inference.config import Config
 from neuronpedia_inference.sae_manager import SAEManager
 from neuronpedia_inference.shared import (
     Model,
+    calculate_per_source_dfa,
+    get_layer_num_from_sae_id,
+    safe_cast,
     with_request_lock,
 )
 
@@ -93,24 +95,6 @@ async def activation_all(
             content={"error": "An error occurred while processing the request"},
             status_code=500,
         )
-
-
-def _get_safe_dtype(dtype: torch.dtype) -> torch.dtype:
-    """
-    Convert float16 to float32, leave other dtypes unchanged.
-    """
-    return torch.float32 if dtype == torch.float16 else dtype
-
-
-def _safe_cast(tensor: torch.Tensor, target_dtype: torch.dtype) -> torch.Tensor:
-    """
-    Safely cast a tensor to the target dtype, creating a copy if needed.
-    Convert float16 to float32, leave other dtypes unchanged.
-    """
-    safe_dtype = _get_safe_dtype(tensor.dtype)
-    if safe_dtype != tensor.dtype or safe_dtype != target_dtype:
-        return tensor.to(target_dtype)
-    return tensor
 
 
 class ActivationProcessor:
@@ -355,61 +339,17 @@ class ActivationProcessor:
         v = cache["v", layer_num]
         attn_weights = cache["pattern", layer_num]
 
-        # Determine the safe dtype for operations
-        v_dtype = _get_safe_dtype(v.dtype)
-        attn_weights_dtype = _get_safe_dtype(attn_weights.dtype)
-        encoder_dtype = _get_safe_dtype(encoder.W_enc.dtype)
-
-        # Use the highest precision dtype
-        op_dtype = max(
-            v_dtype,
-            attn_weights_dtype,
-            encoder_dtype,
-            key=lambda x: x.itemsize,
+        result = calculate_per_source_dfa(
+            model=model,
+            encoder=encoder,
+            v=v,
+            attn_weights=attn_weights,
+            feature_index=idx,
+            max_value_index=max_value_index,
         )
-
-        # Check if the model uses GQA
-        use_gqa = (
-            hasattr(model.cfg, "n_key_value_heads")
-            and model.cfg.n_key_value_heads is not None
-            and model.cfg.n_key_value_heads < model.cfg.n_heads
-        )
-
-        if use_gqa:
-            n_query_heads = attn_weights.shape[1]
-            n_kv_heads = v.shape[2]
-            expansion_factor = n_query_heads // n_kv_heads
-            v = v.repeat_interleave(expansion_factor, dim=2)
-
-        # Cast tensors to operation dtype
-        v = _safe_cast(v, op_dtype)
-        attn_weights = _safe_cast(attn_weights, op_dtype)
-
-        v_cat = einops.rearrange(
-            v, "batch src_pos n_heads d_head -> batch src_pos (n_heads d_head)"
-        )
-
-        attn_weights_bcast = einops.repeat(
-            attn_weights,
-            "batch n_heads dest_pos src_pos -> batch dest_pos src_pos (n_heads d_head)",
-            d_head=model.cfg.d_head,
-        )
-
-        decomposed_z_cat = attn_weights_bcast * v_cat.unsqueeze(1)
-
-        # Cast encoder weights to operation dtype
-        W_enc = _safe_cast(encoder.W_enc[:, idx], op_dtype)
-
-        per_src_pos_dfa = einops.einsum(
-            decomposed_z_cat,
-            W_enc,
-            "batch dest_pos src_pos d_model, d_model -> batch dest_pos src_pos",
-        )
-
-        result = per_src_pos_dfa[torch.arange(1), torch.tensor([max_value_index]), :]
 
         # Cast the result back to the original dtype of v
-        return _safe_cast(result, v.dtype)
+        return safe_cast(result, v.dtype)
 
     def _calculate_table_counts(
         self,
@@ -435,7 +375,7 @@ class ActivationProcessor:
     def _get_layer_num(sae_id: str) -> int:
         """Get layer number from SAE ID."""
         try:
-            return int(sae_id.split("-")[0]) if not sae_id.isdigit() else int(sae_id)
+            return get_layer_num_from_sae_id(sae_id)
 
         except ValueError:
             if "blocks" in sae_id:

--- a/apps/inference/neuronpedia_inference/shared.py
+++ b/apps/inference/neuronpedia_inference/shared.py
@@ -1,6 +1,8 @@
 import asyncio
 from functools import wraps
+from typing import Any
 
+import einops
 import torch
 from transformer_lens import HookedTransformer
 
@@ -40,3 +42,96 @@ STR_TO_DTYPE = {
     "float16": torch.float16,
     "bfloat16": torch.bfloat16,
 }
+
+
+def _get_safe_dtype(dtype: torch.dtype) -> torch.dtype:
+    """
+    Convert float16 to float32, leave other dtypes unchanged.
+    """
+    return torch.float32 if dtype == torch.float16 else dtype
+
+
+def safe_cast(tensor: torch.Tensor, target_dtype: torch.dtype) -> torch.Tensor:
+    """
+    Safely cast a tensor to the target dtype, creating a copy if needed.
+    Convert float16 to float32, leave other dtypes unchanged.
+    """
+    safe_dtype = _get_safe_dtype(tensor.dtype)
+    if safe_dtype != tensor.dtype or safe_dtype != target_dtype:
+        return tensor.to(target_dtype)
+    return tensor
+
+
+def calculate_per_source_dfa(
+    model: HookedTransformer,
+    encoder: Any,
+    v: torch.Tensor,
+    attn_weights: torch.Tensor,
+    feature_index: int,
+    max_value_index: int,
+) -> torch.Tensor:
+    """
+    Core DFA calculation logic that can be shared between different endpoints.
+
+    Args:
+        model: The transformer model
+        encoder: The SAE or encoder object with W_enc attribute
+        v: The value tensor from cache
+        attn_weights: The attention pattern tensor from cache
+        feature_index: Index of the feature in the encoder
+        max_value_index: Index where maximum activation occurs
+
+    Returns:
+        Tensor with the raw DFA values (before formatting or casting)
+    """
+    # Determine the safe dtype for operations
+    v_dtype = _get_safe_dtype(v.dtype)
+    attn_weights_dtype = _get_safe_dtype(attn_weights.dtype)
+    encoder_dtype = _get_safe_dtype(encoder.W_enc.dtype)
+
+    # Use the highest precision dtype
+    op_dtype = max(v_dtype, attn_weights_dtype, encoder_dtype, key=lambda x: x.itemsize)
+
+    # Check if the model uses GQA
+    use_gqa = (
+        hasattr(model.cfg, "n_key_value_heads")
+        and model.cfg.n_key_value_heads is not None
+        and model.cfg.n_key_value_heads < model.cfg.n_heads
+    )
+
+    if use_gqa:
+        n_query_heads = attn_weights.shape[1]
+        n_kv_heads = v.shape[2]
+        expansion_factor = n_query_heads // n_kv_heads
+        v = v.repeat_interleave(expansion_factor, dim=2)
+
+    # Cast tensors to operation dtype
+    v = safe_cast(v, op_dtype)
+    attn_weights = safe_cast(attn_weights, op_dtype)
+
+    v_cat = einops.rearrange(
+        v, "batch src_pos n_heads d_head -> batch src_pos (n_heads d_head)"
+    )
+
+    attn_weights_bcast = einops.repeat(
+        attn_weights,
+        "batch n_heads dest_pos src_pos -> batch dest_pos src_pos (n_heads d_head)",
+        d_head=model.cfg.d_head,
+    )
+
+    decomposed_z_cat = attn_weights_bcast * v_cat.unsqueeze(1)
+
+    # Cast encoder weights to operation dtype
+    W_enc = safe_cast(encoder.W_enc[:, feature_index], op_dtype)
+
+    per_src_pos_dfa = einops.einsum(
+        decomposed_z_cat,
+        W_enc,
+        "batch dest_pos src_pos d_model, d_model -> batch dest_pos src_pos",
+    )
+
+    return per_src_pos_dfa[torch.arange(1), torch.tensor([max_value_index]), :]
+
+
+def get_layer_num_from_sae_id(sae_id: str) -> int:
+    return int(sae_id.split("-")[0]) if not sae_id.isdigit() else int(sae_id)

--- a/apps/inference/tests/unit/test_all.py
+++ b/apps/inference/tests/unit/test_all.py
@@ -1,0 +1,295 @@
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import torch
+from neuronpedia_inference_client.models.activation_all_post200_response import (
+    ActivationAllPost200Response,
+)
+from neuronpedia_inference_client.models.activation_all_post_request import (
+    ActivationAllPostRequest,
+)
+from sae_lens import SAE
+from transformer_lens import ActivationCache, HookedTransformer
+
+from neuronpedia_inference.endpoints.activation.all import ActivationProcessor
+
+
+@pytest.fixture
+def mock_model() -> Mock:
+    """Mock transformer model for testing."""
+    model = Mock(spec=HookedTransformer)
+    model.cfg = Mock()
+    model.cfg.n_layers = 4
+    model.cfg.default_prepend_bos = True
+    model.to_tokens.return_value = torch.tensor([[1, 2, 3, 4, 5]])
+    model.to_str_tokens.return_value = ["<BOS>", "hello", "world", "test", "<EOS>"]
+
+    # Mock cache data
+    cache_data = {}
+    cache_data["blocks.0.hook_mlp_out"] = torch.randn(1, 5, 64)
+    cache_data["blocks.1.hook_mlp_out"] = torch.randn(1, 5, 64)
+    # Add cache data for all layers that might be accessed
+    for layer in range(4):  # n_layers = 4
+        cache_data["v", layer] = torch.randn(1, 5, 4, 16)
+        cache_data["pattern", layer] = torch.randn(1, 4, 5, 5)
+
+    cache = Mock(spec=ActivationCache)
+    # cache.__getitem__ = lambda self, key: cache_data[key]
+    cache.__getitem__ = lambda _, key: cache_data[key]
+
+    model.run_with_cache.return_value = (None, cache)
+    return model
+
+
+@pytest.fixture
+def mock_sae() -> Mock:
+    """Mock SAE for testing."""
+    sae = Mock(spec=SAE)
+    sae.cfg = Mock()
+    sae.cfg.prepend_bos = True
+    sae.encode.return_value = torch.randn(1, 5, 128)
+    return sae
+
+
+@pytest.fixture
+def mock_sae_manager() -> Mock:
+    """Mock SAE manager for testing."""
+    manager = Mock()
+    # Create a more flexible mock SAE that allows attribute access
+    mock_sae = Mock()
+    mock_sae.cfg = Mock()
+    mock_sae.cfg.prepend_bos = True
+    mock_sae.encode.return_value = torch.randn(1, 5, 128)
+
+    manager.get_sae.return_value = mock_sae
+    manager.get_sae_hook.return_value = "blocks.0.hook_mlp_out"
+    manager.get_sae_type.return_value = "features"
+    manager.is_dfa_enabled.return_value = False
+    manager.sae_set_to_saes = {"test_set": ["0-test_set", "1-test_set"]}
+    return manager
+
+
+@pytest.fixture
+def mock_config() -> Mock:
+    """Mock config for testing."""
+    config = Mock()
+    config.device = "cpu"
+    config.token_limit = 1000
+    return config
+
+
+@pytest.fixture
+def sample_request() -> ActivationAllPostRequest:
+    """Sample activation request for testing."""
+    return ActivationAllPostRequest(
+        model="test_model",
+        prompt="hello world test",
+        source_set="test_set",
+        selected_sources=["0-test_set", "1-test_set"],
+        num_results=10,
+        sort_by_token_indexes=[],
+        ignore_bos=False,
+        feature_filter=None,
+    )
+
+
+@pytest.fixture
+def processor() -> ActivationProcessor:
+    """ActivationProcessor instance for testing."""
+    return ActivationProcessor()
+
+
+@patch("neuronpedia_inference.endpoints.activation.all.Model")
+@patch("neuronpedia_inference.endpoints.activation.all.SAEManager")
+@patch("neuronpedia_inference.endpoints.activation.all.Config")
+def test_process_activations_basic(
+    mock_config_class: MagicMock,
+    mock_sae_manager_class: MagicMock,
+    mock_model_class: MagicMock,
+    processor: ActivationProcessor,
+    sample_request: ActivationAllPostRequest,
+    mock_model: Mock,
+    mock_sae_manager: Mock,
+    mock_config: Mock,
+):
+    """Test basic process_activations functionality."""
+    # Setup mocks
+    mock_model_class.get_instance.return_value = mock_model
+    mock_sae_manager_class.get_instance.return_value = mock_sae_manager
+    mock_config_class.get_instance.return_value = mock_config
+    # Execute
+    result = processor.process_activations(sample_request)
+    # Verify result structure
+    assert isinstance(result, ActivationAllPost200Response)
+    assert hasattr(result, "activations")
+    assert hasattr(result, "tokens")
+    assert hasattr(result, "counts")
+    assert isinstance(result.tokens, list)
+    assert isinstance(result.counts, list)
+    # Verify model interactions
+    mock_model.to_tokens.assert_called_once()
+    mock_model.to_str_tokens.assert_called_once()
+    mock_model.run_with_cache.assert_called_once()
+
+
+@patch("neuronpedia_inference.endpoints.activation.all.Model")
+@patch("neuronpedia_inference.endpoints.activation.all.SAEManager")
+@patch("neuronpedia_inference.endpoints.activation.all.Config")
+def test_process_activations_with_sort_by_token_indexes(
+    mock_config_class: MagicMock,
+    mock_sae_manager_class: MagicMock,
+    mock_model_class: MagicMock,
+    processor: ActivationProcessor,
+    sample_request: ActivationAllPostRequest,
+    mock_model: Mock,
+    mock_sae_manager: Mock,
+    mock_config: Mock,
+):
+    """Test process_activations with sort_by_token_indexes."""
+    # Setup mocks
+    mock_model_class.get_instance.return_value = mock_model
+    mock_sae_manager_class.get_instance.return_value = mock_sae_manager
+    mock_config_class.get_instance.return_value = mock_config
+    # Modify request to include sort_by_token_indexes
+    sample_request.sort_by_token_indexes = [1, 2, 3]
+    # Execute
+    result = processor.process_activations(sample_request)
+    # Verify result
+    assert isinstance(result, ActivationAllPost200Response)
+    assert len(result.tokens) == 5  # Should match mock token length
+
+
+@patch("neuronpedia_inference.endpoints.activation.all.Model")
+@patch("neuronpedia_inference.endpoints.activation.all.SAEManager")
+@patch("neuronpedia_inference.endpoints.activation.all.Config")
+def test_process_activations_with_feature_filter(
+    mock_config_class: MagicMock,
+    mock_sae_manager_class: MagicMock,
+    mock_model_class: MagicMock,
+    processor: ActivationProcessor,
+    sample_request: ActivationAllPostRequest,
+    mock_model: Mock,
+    mock_sae_manager: Mock,
+    mock_config: Mock,
+):
+    """Test process_activations with feature filter."""
+    # Setup mocks
+    mock_model_class.get_instance.return_value = mock_model
+    mock_sae_manager_class.get_instance.return_value = mock_sae_manager
+    mock_config_class.get_instance.return_value = mock_config
+    # Modify request for single layer with feature filter
+    sample_request.selected_sources = ["0-test_set"]
+    sample_request.feature_filter = [0, 1, 5, 10]
+    # Execute
+    result = processor.process_activations(sample_request)
+    # Verify result
+    assert isinstance(result, ActivationAllPost200Response)
+
+
+@patch("neuronpedia_inference.endpoints.activation.all.Model")
+@patch("neuronpedia_inference.endpoints.activation.all.SAEManager")
+@patch("neuronpedia_inference.endpoints.activation.all.Config")
+def test_process_activations_with_neurons_sae_type(
+    mock_config_class: MagicMock,
+    mock_sae_manager_class: MagicMock,
+    mock_model_class: MagicMock,
+    processor: ActivationProcessor,
+    sample_request: ActivationAllPostRequest,
+    mock_model: Mock,
+    mock_sae_manager: Mock,
+    mock_config: Mock,
+):
+    """Test process_activations with neurons SAE type."""
+    # Setup mocks
+    mock_model_class.get_instance.return_value = mock_model
+    mock_sae_manager_class.get_instance.return_value = mock_sae_manager
+    mock_config_class.get_instance.return_value = mock_config
+    # Configure SAE manager to return neurons type
+    mock_sae_manager.get_sae_type.return_value = "neurons"
+    # Execute
+    result = processor.process_activations(sample_request)
+    # Verify result
+    assert isinstance(result, ActivationAllPost200Response)
+
+
+@patch("neuronpedia_inference.endpoints.activation.all.Model")
+@patch("neuronpedia_inference.endpoints.activation.all.SAEManager")
+@patch("neuronpedia_inference.endpoints.activation.all.Config")
+def test_process_activations_with_dfa_enabled(
+    mock_config_class: MagicMock,
+    mock_sae_manager_class: MagicMock,
+    mock_model_class: MagicMock,
+    processor: ActivationProcessor,
+    sample_request: ActivationAllPostRequest,
+    mock_model: Mock,
+    mock_sae_manager: Mock,
+    mock_config: Mock,
+):
+    """Test process_activations with DFA calculation enabled."""
+    # Setup mocks
+    mock_model_class.get_instance.return_value = mock_model
+    mock_sae_manager_class.get_instance.return_value = mock_sae_manager
+    mock_config_class.get_instance.return_value = mock_config
+    # Enable DFA
+    mock_sae_manager.is_dfa_enabled.return_value = True
+    # Mock calculate_per_source_dfa function
+    with patch(
+        "neuronpedia_inference.endpoints.activation.all.calculate_per_source_dfa"
+    ) as mock_dfa:
+        # Return a 2D tensor where first dimension can be indexed
+        mock_dfa.return_value = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5]])
+        # Execute
+        result = processor.process_activations(sample_request)
+        # Verify result
+        assert isinstance(result, ActivationAllPost200Response)
+        # Check that DFA was called
+        mock_dfa.assert_called()
+
+
+@patch("neuronpedia_inference.endpoints.activation.all.Model")
+@patch("neuronpedia_inference.endpoints.activation.all.SAEManager")
+@patch("neuronpedia_inference.endpoints.activation.all.Config")
+def test_process_activations_invalid_token_index(
+    mock_config_class: MagicMock,
+    mock_sae_manager_class: MagicMock,
+    mock_model_class: MagicMock,
+    processor: ActivationProcessor,
+    sample_request: ActivationAllPostRequest,
+    mock_model: Mock,
+    mock_sae_manager: Mock,
+    mock_config: Mock,
+):
+    """Test process_activations raises error for invalid sort_by_token_indexes."""
+    # Setup mocks
+    mock_model_class.get_instance.return_value = mock_model
+    mock_sae_manager_class.get_instance.return_value = mock_sae_manager
+    mock_config_class.get_instance.return_value = mock_config
+    # Set invalid token index (beyond token length)
+    sample_request.sort_by_token_indexes = [10]  # tokens only go 0-4
+    with pytest.raises(ValueError, match="Sort by token index .* is out of range"):
+        processor.process_activations(sample_request)
+
+
+@patch("neuronpedia_inference.endpoints.activation.all.Model")
+@patch("neuronpedia_inference.endpoints.activation.all.SAEManager")
+@patch("neuronpedia_inference.endpoints.activation.all.Config")
+def test_process_activations_ignore_bos(
+    mock_config_class: MagicMock,
+    mock_sae_manager_class: MagicMock,
+    mock_model_class: MagicMock,
+    processor: ActivationProcessor,
+    sample_request: ActivationAllPostRequest,
+    mock_model: Mock,
+    mock_sae_manager: Mock,
+    mock_config: Mock,
+):
+    """Test process_activations with ignore_bos=True."""
+    # Setup mocks
+    mock_model_class.get_instance.return_value = mock_model
+    mock_sae_manager_class.get_instance.return_value = mock_sae_manager
+    mock_config_class.get_instance.return_value = mock_config
+    sample_request.ignore_bos = True
+    # Execute
+    result = processor.process_activations(sample_request)
+    # Verify result
+    assert isinstance(result, ActivationAllPost200Response)

--- a/apps/inference/tests/unit/test_single.py
+++ b/apps/inference/tests/unit/test_single.py
@@ -1,0 +1,226 @@
+import time
+
+import pytest
+import torch
+from sae_lens import SAE, SAEConfig
+from transformer_lens import HookedTransformer
+
+from neuronpedia_inference.endpoints.activation.single import calculate_dfa
+
+
+@pytest.fixture
+def model() -> HookedTransformer:
+    model = HookedTransformer.from_pretrained("tiny-stories-1M", device="cpu")
+    model.eval()
+    return model
+
+
+@pytest.fixture
+def sae() -> SAE:
+    cfg = SAEConfig(
+        architecture="standard",
+        d_in=64,
+        d_sae=128,
+        apply_b_dec_to_input=False,
+        context_size=128,
+        model_name="TEST",
+        hook_name="test",
+        hook_layer=0,
+        prepend_bos=True,
+        dataset_path="test/test",
+        dtype="float32",
+        activation_fn_str="relu",
+        finetuning_scaling_factor=False,
+        hook_head_index=None,
+        normalize_activations="none",
+        device="cpu",
+        sae_lens_training_version=None,
+        dataset_trust_remote_code=True,
+    )
+
+    sae = SAE(cfg)
+    # set weights and biases to hardcoded values so tests are consistent
+    seed1 = torch.tensor([0.1, -0.2, 0.3, -0.4] * 16)  # 64
+    seed2 = torch.tensor([0.2, -0.1, 0.4, -0.2] * 32)  # 64 x 2
+    seed3 = torch.tensor([0.3, -0.3, 0.6, -0.6] * 16)  # 64
+    seed4 = torch.tensor([-0.4, 0.4, 0.8, -0.8] * 32)  # 64 x 2
+    W_enc_base = torch.cat([torch.eye(64), torch.eye(64)], dim=-1)
+    W_dec_base = torch.cat([torch.eye(64), torch.eye(64)], dim=0)
+    sae.load_state_dict(
+        {
+            "W_enc": W_enc_base + torch.outer(seed1, seed2),
+            "W_dec": W_dec_base + torch.outer(seed4, seed3),
+            "b_enc": torch.zeros_like(sae.b_enc) + 0.5,
+            "b_dec": torch.zeros_like(sae.b_dec) + 0.3,
+        }
+    )
+    return sae
+
+
+@pytest.fixture
+def tokens(model: HookedTransformer) -> torch.Tensor:
+    return model.to_tokens(
+        [
+            "But what about second breakfast?" * 3,
+            "Nothing is cheesier than cheese." * 3,
+        ]
+    )
+
+
+def test_calculate_dfa_shape(model: HookedTransformer, sae: SAE, tokens: torch.Tensor):
+    layer_num = 0
+    index = 0
+    max_value_index = 5
+
+    result = calculate_dfa(
+        model,
+        sae=sae,
+        layer_num=layer_num,
+        index=index,
+        max_value_index=max_value_index,
+        tokens=tokens,
+    )
+
+    assert "dfa_values" in result
+    assert "dfa_target_index" in result
+    assert "dfa_max_value" in result
+
+    assert isinstance(result["dfa_values"], list)
+    assert isinstance(result["dfa_target_index"], int)
+    assert isinstance(result["dfa_max_value"], float)
+    assert len(result["dfa_values"]) == tokens.shape[1]  # Should match sequence length
+    assert result["dfa_target_index"] == max_value_index
+
+
+def test_calculate_dfa_values(model: HookedTransformer, sae: SAE, tokens: torch.Tensor):
+    layer_num = 0
+    index = 0
+    max_value_index = 3
+
+    result = calculate_dfa(
+        model,
+        sae=sae,
+        layer_num=layer_num,
+        index=index,
+        max_value_index=max_value_index,
+        tokens=tokens,
+    )
+
+    dfa_values = result["dfa_values"]
+    assert isinstance(dfa_values, list)
+    assert len(dfa_values) == tokens.shape[1]
+    assert not all(v == 0 for v in dfa_values)
+    assert result["dfa_max_value"] == max(dfa_values)
+
+
+def test_calculate_dfa_different_layers(
+    model: HookedTransformer, sae: SAE, tokens: torch.Tensor
+):
+    index = 0
+    max_value_index = 2
+
+    result_layer0 = calculate_dfa(
+        model,
+        sae=sae,
+        layer_num=0,
+        index=index,
+        max_value_index=max_value_index,
+        tokens=tokens,
+    )
+    result_layer1 = calculate_dfa(
+        model,
+        sae=sae,
+        layer_num=1,
+        index=index,
+        max_value_index=max_value_index,
+        tokens=tokens,
+    )
+
+    # Results should be different for different layers
+    assert result_layer0["dfa_values"] != result_layer1["dfa_values"]
+
+
+def test_calculate_dfa_target_index(
+    model: HookedTransformer, sae: SAE, tokens: torch.Tensor
+):
+    layer_num = 0
+    index = 0
+
+    # Test with max_value_index at sequence boundaries
+    result_first = calculate_dfa(
+        model,
+        sae=sae,
+        layer_num=layer_num,
+        index=index,
+        max_value_index=0,
+        tokens=tokens,
+    )
+    result_last = calculate_dfa(
+        model,
+        sae=sae,
+        layer_num=layer_num,
+        index=index,
+        max_value_index=tokens.shape[1] - 1,
+        tokens=tokens,
+    )
+    assert result_first["dfa_target_index"] == 0
+    assert result_last["dfa_target_index"] == tokens.shape[1] - 1
+
+
+def test_calculate_dfa_performance_comparison(model: HookedTransformer, sae: SAE):
+    # Create larger tokens for performance testing
+    large_tokens = model.to_tokens(["This is a longer test sequence. " * 20] * 4)
+
+    layer_num = 0
+    index = 0
+    max_value_index = large_tokens.shape[1] // 2
+
+    start_time = time.time()
+    result = calculate_dfa(
+        model,
+        sae=sae,
+        layer_num=layer_num,
+        index=index,
+        max_value_index=max_value_index,
+        tokens=large_tokens,
+    )
+    end_time = time.time()
+
+    # Should complete in reasonable time
+    assert end_time - start_time < 10, "Function took too long"
+    dfa_values = result["dfa_values"]
+    assert isinstance(dfa_values, list)
+    assert len(dfa_values) == large_tokens.shape[1]
+
+
+def test_calculate_dfa_different_shapes(model: HookedTransformer, sae: SAE):
+    layer_num = 0
+    index = 0
+
+    # Test with different sequence lengths
+    shapes = [
+        model.to_tokens(["Short text."]),
+        model.to_tokens(["Medium length text sequence here."]),
+        model.to_tokens(
+            [
+                "Much longer text sequence that spans multiple tokens and tests the function with larger inputs."
+            ]
+        ),
+    ]
+
+    for tokens in shapes:
+        max_value_index = tokens.shape[1] // 2
+        result = calculate_dfa(
+            model,
+            sae=sae,
+            layer_num=layer_num,
+            index=index,
+            max_value_index=max_value_index,
+            tokens=tokens,
+        )
+
+        dfa_values = result["dfa_values"]
+        assert isinstance(dfa_values, list)
+        assert len(dfa_values) == tokens.shape[1]
+        assert result["dfa_target_index"] == max_value_index
+        assert isinstance(result["dfa_max_value"], float)


### PR DESCRIPTION
### Problem

- `all.py` and `single.py` both contain functions `_get_safe_dtype()` and `_safe_cast()`
- `all.py` and `single.py` duplicate `get_layer_num_from_sae_id()`
- A large block of code to calculate DFA values has been practically duplicated in `all.py` and `single.py`, and so it seems unlikely we'll want to change it in two places.

### Fix 

- Moving one pair of functions `_get_safe_dtype()` and `_safe_cast()` to `shared.py` and deleting the other pair.
- Moving `get_layer_num_from_sae_id()` to `shared.py`.
- Extracting the large block of code to `calculate_per_source_dfa()`.

### Testing

- I compared code I thought to be duplicated at www.diffchecker.com.
- I ran `make check-ci`.
