### PR TITLE
fix: Makefile errors caused by wrong cmd checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ init-env: ## Initialize the environment
 
 webapp-demo-build: ## Webapp: Public Demo Environment - Build
 	@echo "Building the webapp for connecting to the public demo database and servers..."
-	@if ! command -v docker &> /dev/null; then \
+	@if ! which docker > /dev/null 2>&1; then \
 		echo "Error: Docker is not installed. Please install Docker first."; \
 		exit 1; \
 	fi
@@ -80,7 +80,7 @@ install-nodejs: # Install Node.js for Webapp
 webapp-localhost-install: ## Webapp: Localhost Environment - Install Dependencies (Development Build)
 	@echo "Installing the webapp dependencies for development in the localhost environment..."
 	# check if npm exists
-	if ! command -v npm &> /dev/null; then \
+	if ! which npm > /dev/null 2>&1; then \
 		echo "Error: npm is not installed. Please install nodejs first with 'make install-nodejs'."; \
 		exit 1; \
 	fi
@@ -89,7 +89,7 @@ webapp-localhost-install: ## Webapp: Localhost Environment - Install Dependencie
 	
 webapp-localhost-dev: ## Webapp: Localhost Environment - Run (Development Build)
 	@echo "Bringing up the webapp for development and connecting to the localhost database..."
-	@if ! command -v docker &> /dev/null; then \
+	@if ! which docker > /dev/null 2>&1; then \
 		echo "Error: Docker is not installed. Please install Docker first."; \
 		exit 1; \
 	fi
@@ -102,7 +102,7 @@ webapp-localhost-dev: ## Webapp: Localhost Environment - Run (Development Build)
 
 webapp-localhost-test: ## Webapp: Localhost Environment - Run (Playwright)
 	@echo "Bringing up the webapp for development and connecting to the localhost database..."
-	@if ! command -v docker &> /dev/null; then \
+	@if ! which docker > /dev/null 2>&1; then \
 		echo "Error: Docker is not installed. Please install Docker first."; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Problem: 
* Running Makefile `webapp-` subcommands incorrectly flags missing dependencies on vanilla Linux VM (e.g, `webapp-localhost-install`).
* This halts container build, and blocks contributions to project

Fix: 
* Standardised to match the existing pattern in other commands.
* Specifically: changed lines with `command -v docker` to be `which docker`; and corrected the output redirection.

Testing:
* Validated on new vanilla Linux VM and on my Macbook; `make` commands now run with no issue.
* Also validated that `make` commands successfully error if a dependency is missing (ie, confirmed that there are no false negatives).