### PR TITLE
[inference] fix: docker localhost inference issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,9 @@ webapp-localhost-test: ## Webapp: Localhost Environment - Run (Playwright)
 inference-localhost-install: ## Inference: Localhost Environment - Install Dependencies (Development Build)
 	@echo "Installing the inference dependencies for development in the localhost environment..."
 	cd apps/inference && \
-	poetry install
+	poetry remove neuronpedia-inference-client || true && \
+	poetry add ../../packages/python/neuronpedia-inference-client && \
+	poetry lock && poetry install
 
 inference-localhost-build: ## Inference: Localhost Environment - Build
 	@echo "Building the inference server for the localhost environment..."

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
     ports:
       - "5002:5002"
     env_file:
-      - ${ENV_FILE:-.env.inference.$(MODEL_SOURCESET)}
+      - ${ENV_FILE:-${MODEL_SOURCESET:+.env.inference.${MODEL_SOURCESET}}.env}
     environment:
       - HF_TOKEN=${HF_TOKEN}
       - SECRET=${INFERENCE_SERVER_SECRET}


### PR DESCRIPTION
### Problem

Two issues with the docker localhost inference `make inference-localhost-install`:
1) `make reset-docker-data` failed because it looked for a `MODEL_SOURCESET` environment variable that didn't exist
2) `make inference-localhost-install` error: Docker's Inference Poetry did not pick up new changes from updates to `neuronpedia-inference-client`, resulting in errors (specifically, it couldn't import the new /tokenize endpoint from #68 )

### Fix 

1) update `docker-compose.yaml` to have a fallback for the errored env_file value
2) update the `inference-localhost-install` target to force uninstall the `neuronpedia-inference-client` package and force reinstall it, picking up the new changes. also added `poetry lock` here.

### Testing

- tested both make commands.
- tested `make inference-localhost-build` and `make inference-localhost-dev` to ensure new install works fine