### PR TITLE
[autointerp] fix: target correct docker service

### DIFF
--- a/docker-compose.autointerp.gpu.yaml
+++ b/docker-compose.autointerp.gpu.yaml
@@ -1,5 +1,5 @@
 services:
-  inference:
+  autointerp:
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
### Problem

* The AutoInterp GPU Compose incorrectly targeted the inference service to enable GPU passthrough.
* This actually prevented the local autointerp service from working; forcing an OpenAI dependency for feature explanations (I had to add my OpenAI key to get it working at all until I figured this out).

### Fix 

* Changed the word "inference" to be "autointerp" such that the correct service uses a GPU.

### Testing

* TODO, confirm that autointerp now correctly works (it wasn't before.)