### PR TITLE
deletes tool.pyright include and exclude lines

### DIFF
--- a/apps/autointerp/pyproject.toml
+++ b/apps/autointerp/pyproject.toml
@@ -37,8 +37,6 @@ build-backend = "poetry.core.masonry.api"
 "typing.List".msg = "Use 'list' instead"
 
 [tool.pyright]
-include = ["neuronpedia_autointerp"]
-exclude = ["dist", "*.venv"]
 # Add this line to ignore import errors for missing libraries
 reportMissingImports = "none"
 typeCheckingMode = "strict"

--- a/apps/inference/pyproject.toml
+++ b/apps/inference/pyproject.toml
@@ -55,8 +55,6 @@ select = ["UP", "TID", "I", "F", "E", "ARG", "SIM", "RET", "LOG", "T20"]
 "typing.List".msg = "Use `list` instead"
 
 [tool.pyright]
-include = ["sae_vis"]
-exclude = ["sae_vis/css", "sae_vis/js", "sae_vis/html", "dist"]
 typeCheckingMode = "strict"
 reportMissingTypeStubs = "none"
 reportUnknownMemberType = "none"


### PR DESCRIPTION
### Problem

- In `inference/pyproject.toml`, the `tool.pyright` subtable contains paths to consider/not consider part of the project that look like they were accidentally copy-pasted from the `sae_vis` repo, or mistakenly added by an LLM.
- I don't think we should specify these paths anyways, since I think we want to consider everything in the same directory as `pyproject.toml` as part of the project.

### Fix 

Removing the `include` and `exclude` lines in the `tool.pyright` subtables in `pyproject.toml` files.

### Testing

I ran `make check-ci`.
