### PR TITLE
fixes Makefiles for python apps

### DIFF
--- a/apps/autointerp/Makefile
+++ b/apps/autointerp/Makefile
@@ -1,4 +1,4 @@
-.PHONY: unit-test format check-format
+.PHONY: test format check-format
 
 # Variables
 POETRY = poetry
@@ -6,8 +6,8 @@ PYTEST = $(POETRY) run pytest
 PYTEST_ARGS = -v -s
 RUFF = $(POETRY) run ruff
 
-unit-test:
-	$(POETRY) run $(PYTEST) -v --cov=neuronpedia_autointerp/ --cov-report=term-missing --cov-branch tests/unit
+test:
+	$(POETRY) run $(PYTEST) -v --cov=neuronpedia_autointerp/ --cov-report=term-missing --cov-branch tests
 
 format:
 	$(RUFF) format .
@@ -20,4 +20,4 @@ check-format:
 check-type:
 	$(POETRY) run pyright .
 
-check-ci: check-format check-type unit-test
+check-ci: check-format check-type test

--- a/apps/inference/Makefile
+++ b/apps/inference/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-verbose coverage format unit-test check-format check-ci install install-dev all run-server
+.PHONY: test-verbose coverage format test check-format check-ci install install-dev all run-server
 
 # Variables
 PYTHON = python
@@ -8,11 +8,8 @@ COVERAGE = $(POETRY) run coverage
 RUFF = $(POETRY) run ruff
 
 # Targets
-unit-test:
-	$(POETRY) run $(PYTEST) -v --cov=neuronpedia_inference/ --cov-report=term-missing --cov-branch tests/unit
-
-integration-test:
-	$(POETRY) run $(PYTEST) $(PYTEST_ARGS) tests/integration
+test:
+	$(POETRY) run $(PYTEST) -v --cov=neuronpedia_inference/ --cov-report=term-missing --cov-branch tests
 
 test-verbose:
 	$(POETRY) run $(PYTEST) -vv --no-header
@@ -28,7 +25,7 @@ check-format:
 check-type:
 	$(POETRY) run pyright .
 
-check-ci: check-format check-type unit-test
+check-ci: check-format check-type test
 
 install:
 	$(POETRY) config virtualenvs.create true
@@ -41,4 +38,4 @@ install-dev:
 all: install-dev format check-format test coverage
 
 run-server:
-	$(POETRY) run python server.py
+	$(POETRY) run python start.py


### PR DESCRIPTION
### Problem

- There are references to `test` in `inference/README.md` and `inference/Makefile`, but there's no such target.
- From `apps/inference`, running `make check-ci` doesn't run integration tests.
- From `apps/inference`, `make run-server` doesn't start the server.
- There's a reference to`test` in `autointerp/README.md`, but there's no such target.

### Fix 

- In `inference/Makefile`, replacing the `unit-test` target with a `test` target, and `server.py` with `start.py`.
- In `autointerp/Makefile`, replacing the `unit-test` target with a `test` target.

### Testing

- From `apps/inference`, I ran `make-test`, `make check-ci`, and `make run-server`.
- From `apps/autointerp`, I ran `make test` and `make check-ci`.