### PR TITLE
fix(docker): make `localhost-run`, `localhost-build` commands

### DIFF
--- a/apps/webapp/Dockerfile
+++ b/apps/webapp/Dockerfile
@@ -3,10 +3,12 @@ RUN mkdir /app
 WORKDIR /app
 
 # Copy package files first
-COPY apps/webapp/package.json /app/apps/webapp/
+COPY apps/webapp/package.json apps/webapp/package-lock.json* /app/apps/webapp/
 
-# Install dependencies in a separate layer
-RUN cd apps/webapp && npm install
+
+# Install dependencies in a seperate layer
+RUN cd apps/webapp && npm install && \
+    npm install -g prisma # needed for prisma in build command
 
 # Copy application code after dependencies
 COPY apps/webapp apps/webapp


### PR DESCRIPTION
### Problem

* Both of the `webapp-localhost-[build|run]` commands fail with a strange "module not exported" package.json / npm import error.

### Fix 

* Adjusted the COPY step of npm related files to correctly transfer requirements. Also did an `npm install -g prisma` to enable the final run without needing to consider directory path.

### Testing

* Validated that `make webapp-localhost-dev`,  `make webapp-localhost-build` and `make webapp-localhost-run` now all run successfully on a new clone! 🎉