### PR TITLE
deletes unused inference methods

### DIFF
--- a/apps/inference/neuronpedia_inference/config.py
+++ b/apps/inference/neuronpedia_inference/config.py
@@ -31,7 +31,6 @@ class Config:
         secret: str | None = None,
         port: int = 5000,
         token_limit: int = 100,
-        saes_path: str | None = None,
         valid_completion_types: list[str] = ["default", "steered"],
         num_layers: int | None = None,
         device: str | None = None,
@@ -51,7 +50,6 @@ class Config:
         self.SECRET = secret
         self.PORT = port
         self.TOKEN_LIMIT = token_limit
-        self.SAES_PATH = saes_path
         self.VALID_COMPLETION_TYPES = valid_completion_types
         self.NUM_LAYERS = num_layers
         self.DEVICE = device
@@ -89,13 +87,6 @@ class Config:
         self, steer_special_token_ids: list[int] | set[int]
     ) -> None:
         self.STEER_SPECIAL_TOKEN_IDS = steer_special_token_ids
-
-    def are_models_compatible(self, model_id_1: str, model_id_2: str) -> bool:
-        if model_id_1.endswith("-it"):
-            model_id_1 = model_id_1[:-3]
-        elif model_id_2.endswith("-it"):
-            model_id_2 = model_id_2[:-3]
-        return model_id_1 == model_id_2
 
     def get_valid_model_ids(self):
         return set([sae_set["model"] for sae_set in self.SAE_CONFIG])

--- a/apps/inference/neuronpedia_inference/sae_manager.py
+++ b/apps/inference/neuronpedia_inference/sae_manager.py
@@ -1,10 +1,7 @@
 import logging
 import time
 from collections import OrderedDict
-from pathlib import Path
 from typing import Any
-
-from huggingface_hub import snapshot_download
 
 from neuronpedia_inference.config import (
     Config,
@@ -188,50 +185,6 @@ class SAEManager:
 
         self.sae_set_to_saes[self.NEURONS_SOURCESET] = neurons_sourceset
         return neurons_sourceset
-
-    def download_sae_set(self, sae_set: dict[str, str | bool]) -> Path:
-        sae_set_id = sae_set["set"]
-        sae_set_dir = f"{self.config.MODEL_ID}__{sae_set_id}"
-        sae_set_path = Path(self.config.SAES_PATH).joinpath(sae_set_dir)  # type: ignore
-
-        if (
-            not sae_set["local"] and sae_set["type"] != "saelens-1"
-        ):  # SAE Lens one will download prior to loading.
-            snapshot_download(
-                repo_id=f"{self.config.HUGGINGFACE_ACCOUNT}/{sae_set_dir}",  # type: ignore
-                local_dir=str(sae_set_path),
-            )
-
-        return sae_set_path
-
-    def get_supported_neuronpedia_ids(self):
-        """
-        Get a list of all Neuronpedia IDs supported by the manager.
-
-        Returns:
-            list: A list of all supported Neuronpedia IDs.
-        """
-        neuronpedia_ids = []
-        for data in self.sae_data.values():
-            neuronpedia_id = data.get("neuronpedia_id")
-            if neuronpedia_id is not None:
-                neuronpedia_ids.append(neuronpedia_id)
-        return neuronpedia_ids  # type: ignore
-
-    def get_sae_id_by_neuronpedia_id(self, neuronpedia_id: str):
-        """
-        Retrieve the SAE ID corresponding to a given Neuronpedia ID.
-
-        Args:
-            neuronpedia_id (str): The Neuronpedia ID to search for.
-
-        Returns:
-            str or None: The corresponding SAE ID if found, None otherwise.
-        """
-        for sae_id, data in self.sae_data.items():
-            if data.get("neuronpedia_id") == neuronpedia_id:
-                return sae_id
-        return None
 
     def print_sae_status(self):
         """

--- a/apps/inference/tests/unit/test_config.py
+++ b/apps/inference/tests/unit/test_config.py
@@ -46,7 +46,6 @@ def test_config_initialization(mock_config: Config):
     assert mock_config.SECRET == "test_secret"
     assert mock_config.PORT == 5000
     assert mock_config.TOKEN_LIMIT == 100
-    assert mock_config.SAES_PATH is None
     assert mock_config.VALID_COMPLETION_TYPES == ["DEFAULT", "STEERED"]
     assert mock_config.DEVICE == "cpu"
 
@@ -115,7 +114,6 @@ def test_config_no_filtering(mock_config: Config):
     assert mock_config.SECRET == "test_secret"
     assert mock_config.PORT == 5000
     assert mock_config.TOKEN_LIMIT == 100
-    assert mock_config.SAES_PATH is None
     assert mock_config.VALID_COMPLETION_TYPES == ["DEFAULT", "STEERED"]
     assert mock_config.DEVICE == "cpu"
 


### PR DESCRIPTION
### Problem

There are methods in `apps/inference` that are unused and I don't see where we could use them.

### Fix 

Deleting methods in `apps/inference` that are unused.

### Testing

I ran `make check-ci`.
