### PR TITLE
add make docs-inference-localhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,22 @@ inference-list-configs: ## Inference: List Configurations (possible values for M
 		echo ""; \
 	done
 
+doc-inference-localhost: ## Inference: Generate Interactive API Documentation
+	@echo "Generating interactive API documentation..."
+	@if ! command -v docker &> /dev/null; then \
+		echo "Error: Docker is required to generate API documentation"; \
+		exit 1; \
+	fi
+	@(sleep 2 && \
+		(command -v open > /dev/null && open http://localhost:8080) || \
+		(command -v xdg-open > /dev/null && xdg-open http://localhost:8080) || \
+		echo "Browser auto-open failed. Please manually open: http://localhost:8080") &
+	docker run --rm -p 8080:8080 \
+		-v $(PWD)/schemas/openapi:/tmp/openapi:ro \
+		-e SWAGGER_JSON=/tmp/openapi/inference-server.yaml \
+		-e PERSIST_AUTHORIZATION=true \
+		swaggerapi/swagger-ui
+
 autointerp-localhost-install: ## Autointerp: Localhost Environment - Install Dependencies (Development Build)
 	@echo "Installing the autointerp dependencies for development in the localhost environment..."
 	cd apps/autointerp && \

--- a/README.md
+++ b/README.md
@@ -251,7 +251,12 @@ To interact with the inference server, you have a few options - note that this w
 1.  Load the webapp with the [local database setup](#i-want-to-use-a-local-database--import-more-neuronpedia-data), then using the model / selected source as you would normally do on Neuronpedia.
 2.  Use the pre-generated inference python client at `packages/python/neuronpedia-inference-client` (set environment variable `INFERENCE_SERVER_SECRET` to `public`, or whatever it's set to in `.env.localhost` if you've changed it)
 3.  Use the openapi spec, located at `schemas/openapi/inference-server.yaml` to make calls with any client of your choice.
-4.  [TODO #1](https://github.com/hijohnnylin/neuronpedia/issues/1): Use a documentation generator to make a simple tester-server that can be activated with `make doc-inference-localhost`
+4.  use Swagger UI to make calls in your browser:
+    ```
+    make doc-inference-localhost
+    ```
+
+    > ⚠️ **warning:** once you go to [localhost:8080](http://localhost:8080), you will need to click `Servers` and select `http://localhost:5002/v1`, and click `Authorize` and enter the value from `INFERENCE_SERVER_SECRET` in `.env.localhost` ( the first time).
 
 #### Pre-Loaded Inference Server Configurations
 

--- a/apps/inference/neuronpedia_inference/server.py
+++ b/apps/inference/neuronpedia_inference/server.py
@@ -222,7 +222,8 @@ async def initialize(
 async def check_secret_key(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
-    if request.url.path == "/health":
+    # Allow OPTIONS requests (CORS preflight) and health checks to pass through
+    if request.url.path == "/health" or request.method == "OPTIONS":
         return await call_next(request)
 
     config = Config.get_instance()

--- a/schemas/openapi/inference-server.yaml
+++ b/schemas/openapi/inference-server.yaml
@@ -10,6 +10,9 @@ info:
 
 servers:
   - url: /v1
+    description: Relative URL (requires running on same host)
+  - url: http://localhost:5002/v1
+    description: Local inference server
 
 paths:
   # Activation

--- a/schemas/openapi/inference/paths/activation/all.yaml
+++ b/schemas/openapi/inference/paths/activation/all.yaml
@@ -18,37 +18,45 @@ post:
             prompt:
               type: string
               description: Input text prompt to get activations for
+              example: "The most iconic structure on Earth is"
             model:
               type: string
               description: Name of the model to test activations on
+              example: "gpt2-small"
             source_set:
               type: string
               description: The source set name of the SAEs (eg gemmascope-res-16k)
+              example: "res-jb"
             selected_sources:
               type: array
               default: []
               items:
                 type: string
               description: List of specific SAEs to get activations for (eg ["0-gemmascope-res-65k", "5-gemmascope-res-65k"]). If not specified, will get activations for all SAEs in the source set.
+              example: []
             sort_by_token_indexes:
               type: array
               default: []
               items:
                 type: integer
               description: Sort the results by the sum of the activations at the specified token indexes.
+              example: []
             ignore_bos:
               type: boolean
               default: true
               description: Whether or not to include features whose highest activation value is the BOS token.
+              example: true
             feature_filter:
               type: array
               items:
                 type: integer
               description: Optional. If specified, will only return features that match the indexes specified. Can only be used if we're testing just one SAE ("selected_sources" length = 1).
+              example: []
             num_results:
               type: integer
               default: 25
               description: Optional. The number of top features to return.
+              example: 25
   responses:
     "200":
       description: Successfully retrieved results

--- a/schemas/openapi/inference/paths/activation/single.yaml
+++ b/schemas/openapi/inference/paths/activation/single.yaml
@@ -14,15 +14,19 @@ post:
             prompt:
               type: string
               description: Input text prompt to get activations for
+              example: "The most iconic structure on Earth is"
             model:
               type: string
               description: Name of the model to test activations on
+              example: "gpt2-small"
             source:
               type: string
               description: Source identifier - could be an SAE ID (eg 5-gemmascope-res-16k). Must be specified with "index", or not at all.
+              example: "9-res-jb"
             index:
               type: string
               description: Index of the SAE. Must be specified with "source", or not at all.
+              example: "1124"
             vector:
               type: array
               items:
@@ -31,6 +35,7 @@ post:
             hook:
               type: string
               description: Hook that the custom vector applies to. Must be specified with "vector".
+              example: "blocks.0.hook_resid_pre"
 
   responses:
     "200":

--- a/schemas/openapi/inference/paths/activation/topk-by-token.yaml
+++ b/schemas/openapi/inference/paths/activation/topk-by-token.yaml
@@ -16,19 +16,24 @@ post:
             prompt:
               type: string
               description: Input text prompt to get activations for
+              example: "The most iconic structure on Earth is"
             model:
               type: string
               description: Name of the model to test activations on
+              example: "gpt2-small"
             source:
               type: string
               description: Source identifier - could be an SAE ID (eg 5-gemmascope-res-16k). Must be specified with "index", or not at NPActivationAllRequest.
+              example: "9-res-jb"
             top_k:
               type: integer
               description: The number of features to include for each token position.
+              example: 10
             ignore_bos:
               type: boolean
               default: true
               description: Whether or not to include features whose highest activation value is the BOS token.
+              example: true
   responses:
     "200":
       description: Successfully retrieved results

--- a/schemas/openapi/inference/paths/steer/completion-chat.yaml
+++ b/schemas/openapi/inference/paths/steer/completion-chat.yaml
@@ -21,6 +21,9 @@ post:
                   items:
                     $ref: "../../shared/steer.yaml#/components/schemas/NPSteerChatMessage"
                   description: Array of chat messages to pass to the model
+                  example:
+                    - content: "The most iconic structure on Earth is"
+                      role: "user"
   responses:
     "200":
       description: Successfully retrieved results

--- a/schemas/openapi/inference/paths/steer/completion.yaml
+++ b/schemas/openapi/inference/paths/steer/completion.yaml
@@ -6,6 +6,24 @@ post:
       application/json:
         schema:
           $ref: "../../shared/steer.yaml#/components/schemas/SteerCompletionRequest"
+        example:
+          prompt: "The most iconic structure on Earth is"
+          model: "gpt2-small"
+          steer_method: "SIMPLE_ADDITIVE"
+          normalize_steering: false
+          types: ["STEERED", "DEFAULT"]
+          features:
+            - model: "gpt2-small"
+              source: "9-res-jb"
+              index: 1124
+              strength: 48
+          n_completion_tokens: 50
+          temperature: 0.8
+          strength_multiplier: 1.0
+          freq_penalty: 0.0
+          seed: 42
+          stream: false
+          n_logprobs: 0
   responses:
     200:
       description: Successfully retrieved results

--- a/schemas/openapi/inference/paths/util/sae-topk-by-decoder-cossim.yaml
+++ b/schemas/openapi/inference/paths/util/sae-topk-by-decoder-cossim.yaml
@@ -18,14 +18,18 @@ post:
               items:
                 type: number
               description: Custom vector to find the top features by cossim for.
+              example: [0.1, -0.2, 0.3, 0.5]
             model:
               type: string
               description: Model to compare the vector or feature against.
+              example: "gpt2-small"
             source:
               type: string
               description: Source/SAE ID to compare the vector or feature against.
+              example: "9-res-jb"
             num_results:
               type: integer
+              example: 10
 
   responses:
     "200":

--- a/schemas/openapi/inference/shared/steer.yaml
+++ b/schemas/openapi/inference/shared/steer.yaml
@@ -15,7 +15,7 @@ components:
           properties:
             strength:
               type: number
-              example: 5
+              example: 10
             steering_vector:
               type: array
               items:
@@ -150,25 +150,35 @@ components:
         prompt:
           type: string
           description: Text to pass the model for completion
+          example: "The most iconic structure on Earth is"
         model:
           type: string
           description: Name of the model
+          example: "gpt2-small"
         steer_method:
           $ref: "#/components/schemas/NPSteerMethod"
+          example: "SIMPLE_ADDITIVE"
         normalize_steering:
           type: boolean
           default: false
+          example: false
         types:
           type: array
           items:
             $ref: "#/components/schemas/NPSteerType"
           minItems: 1
           description: Array that specifies whether or not to generate STEERED output, DEFAULT (non-steered) output, or both.
+          example: ["STEERED", "DEFAULT"]
         features:
           type: array
           items:
             $ref: "#/components/schemas/NPSteerFeature"
           description: Features to steer towards or away from
+          example:
+            - model: "gpt2-small"
+              source: "9-res-jb"
+              index: 1124
+              strength: 48
         vectors:
           type: array
           items:
@@ -177,24 +187,31 @@ components:
           type: integer
           minimum: 1
           description: Number of completion tokens to generate
+          example: 50
         temperature:
           type: number
           minimum: 0
+          example: 0.8
         strength_multiplier:
           type: number
           description: The steering strength will be multiplied by this number
+          example: 1.0
         freq_penalty:
           type: number
+          example: 0.0
         seed:
           type: number
+          example: 42
         stream:
           type: boolean
           description: Whether or not to stream responses using Server Side Events (SSE). Note that the OpenAPI spec does not support SSE - you will receive multiple responses with the same format as non-streaming, except with the "output" field chunked.
           default: false
+          example: false
         n_logprobs:
           type: integer
           minimum: 0
           maximum: 10
           default: 0
           description: Number of logprobs to return per token. 0 means no logprobs.
+          example: 0
 paths: {}

--- a/schemas/openapi/shared.yaml
+++ b/schemas/openapi/shared.yaml
@@ -26,10 +26,10 @@ components:
           example: gpt2-small
         source:
           type: string
-          example: 0-res-jb
+          example: "9-res-jb"
         index:
           type: integer
-          example: 14057
+          example: 1124
 
     NPActivation:
       type: object


### PR DESCRIPTION
### Problem

- We have documentation for all `inference` endpoints, but it's just high-level, in Markdown.
- There's a TODO to add `make doc-inference-localhost` and use a documentation generator.

### Fix 

Adding `make doc-inference-localhost`, which uses `schemas/openapi/inference-server.yaml`, and lets developers use Swagger UI to make calls in a browser.

### Testing

I ran `make inference-localhost-dev MODEL_SOURCESET=gpt2-small.res-jb`, then `make doc-inference-localhost`, went to http://localhost:8080, and used Swagger UI to make calls.

Fixes #1
