### PR TITLE
adds make docs-autointerp-localhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,22 @@ autointerp-localhost-dev: ## Autointerp: Localhost Environment - Run (Developmen
 autointerp-localhost-dev-gpu: ## Autointerp: Localhost Environment - Run (Development Build with CUDA). Usage: make autointerp-localhost-dev-gpu [AUTORELOAD=1] [USE_LOCAL_HF_CACHE=1]
 	$(MAKE) autointerp-localhost-dev ENABLE_GPU=1 AUTORELOAD=$(AUTORELOAD)
 
+doc-autointerp-localhost: ## Doc: Generate Interactive API Documentation
+	@echo "Generating interactive API documentation..."
+	@if ! command -v docker &> /dev/null; then \
+		echo "Error: Docker is required to generate API documentation"; \
+		exit 1; \
+	fi
+	@(sleep 2 && \
+		(command -v open > /dev/null && open http://localhost:8080) || \
+		(command -v xdg-open > /dev/null && xdg-open http://localhost:8080) || \
+		echo "Browser auto-open failed. Please manually open: http://localhost:8080") &
+	docker run --rm -p 8080:8080 \
+		-v $(PWD)/schemas/openapi:/tmp/openapi:ro \
+		-e SWAGGER_JSON=/tmp/openapi/autointerp-server.yaml \
+		-e PERSIST_AUTHORIZATION=true \
+		swaggerapi/swagger-ui
+
 reset-docker-data: ## Reset Docker Data - this deletes your local database!
 	@echo "WARNING: This will delete all your local neuronpedia Docker data and databases!"
 	@read -p "Are you sure you want to continue? (y/N) " confirm; \

--- a/README.md
+++ b/README.md
@@ -389,7 +389,12 @@ To interact with the autointerp server, you have a few options:
 
 1. Use the pre-generated autointerp python client at `packages/python/neuronpedia-autointerp-client` (set environment variable `AUTOINTERP_SERVER_SECRET` to `public`, or whatever it's set to in `.env.localhost` if you've changed it)
 2. Use the openapi spec, located at `schemas/openapi/autointerp-server.yaml` to make calls with any client of your choice.
-3. TODO: Use a documentation generator to make a simple tester-server that can be activated with `make doc-autointerp-localhost`
+3. use Swagger UI to make calls in your browser:
+    ```
+    make doc-autointerp-localhost
+    ```
+
+> ⚠️ **warning:** once you go to [localhost:8080](http://localhost:8080), you will need to click `Servers` and select `http://localhost:5003/v1`, and click `Authorize` and enter the value from `AUTOINTERP_SERVER_SECRET` in `.env.localhost` (the first time).
 
 #### Doing Local Autointerp Development
 

--- a/schemas/openapi/autointerp-server.yaml
+++ b/schemas/openapi/autointerp-server.yaml
@@ -10,6 +10,9 @@ info:
 
 servers:
   - url: /v1
+    description: Relative URL (requires running on same host)
+  - url: http://localhost:5003/v1
+    description: Local autointerp server
 
 paths:
   # Explanations


### PR DESCRIPTION
### Problem

- We have documentation for all `autointerp` endpoints, but it's just high-level, in Markdown.
- There's a TODO to add `make doc-autointerp-localhost` and use a documentation generator.

### Fix 

Adding `make doc-autointerp-localhost`, which uses `schemas/openapi/autointerp-server.yaml`, and lets developers use Swagger UI to make calls in a browser.

### Testing

I ran `make autointerp-localhost-dev`, then `make doc-autointerp-localhost`, went to http://localhost:8080/, and used Swagger UI to make calls.

Fixes #120
