### PR TITLE
feat: add support for SMTP email provider

### DIFF
--- a/apps/webapp/lib/env.ts
+++ b/apps/webapp/lib/env.ts
@@ -1,4 +1,5 @@
 import { config } from 'dotenv';
+import { z } from 'zod';
 
 // If it's not undefined, then it's a one click deploy. It doesn't matter what the value itself is.
 // Also, if it's one-click-deploy on Vercel, we always use the demo environment variables.
@@ -51,14 +52,21 @@ export const PUBLIC_ACTIVATIONS_USER_IDS = process.env.PUBLIC_ACTIVATIONS_USER_I
   : ['cljj57d3c000076ei38vwnv35', 'clkht01d40000jv08hvalcvly'];
 
 // Email
-// For email sending providers, choose EITHER AWS SES or Resend.com.
+// For email sending providers, choose either AWS SES, Resend.com, or set custom SMTP server settings.
 // Resend is easier to set up, but AWS is more reliable.
 // If both are defined, AWS will be used.
+// If you have access to a preexisting SMTP server, then setting custom settings will be easier.
+// Note that SMTP authentication is not supported at the time.
+const EmailProviderSchema = z.enum(['aws', 'resend', 'smtp']);
+export const EMAIL_SENDING_PROVIDER = EmailProviderSchema.parse(process.env.EMAIL_SENDING_PROVIDER || 'smtp');
 // AWS
 export const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || '';
 export const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || '';
 // Resend
 export const RESEND_EMAIL_API_KEY = process.env.RESEND_EMAIL_API_KEY || '';
+// Custom SMTP settings
+export const SMTP_SERVER_HOST = process.env.SMTP_SERVER_HOST || '';
+export const SMTP_SERVER_PORT = process.env.SMTP_SERVER_PORT || 25;
 
 // External Services
 // AI API Keys (Mostly for auto-interp for whitelisted accounts)


### PR DESCRIPTION
### Problem

Currently, AWS SES and Resend.com are the only methods for sending emails. This is a barrier to execution for organizations with their own SMTP servers that restrict access to such services. Consequently, users in such environments cannot create user accounts via email magic links.

### Fix 

Add support for SMTP as an email provider.

- Adds environment variable `EMAIL_SENDING_PROVIDER` with supported values `['aws', 'resend', 'smtp']` for toggling between different email providers
- Adds environment variables `SMTP_SERVER_HOST` and `SMTP_SERVER_PORT` for configuring SMTP settings
- Notably, SMTP authentication is not supported/included in this change. I don't have the means of testing this.

### Testing

Tested in a corporate environment with a no-auth SMTP server using default port (25)

<img width="436" height="302" alt="image" src="https://github.com/user-attachments/assets/c8cc3ca9-b6d3-4b8e-82c9-bdb01cfd2727" />

<img width="1206" height="740" alt="image" src="https://github.com/user-attachments/assets/8bfcabf1-3873-419a-baea-7226ab5007ac" />

