### PR TITLE
Fix Docker build by separating database operations from build step

### DIFF
--- a/apps/webapp/Dockerfile
+++ b/apps/webapp/Dockerfile
@@ -60,9 +60,8 @@ RUN chmod +x ./init.sh
 ARG ENV_FILE=.env.localhost
 COPY ${ENV_FILE} .env
 
-# Build with environment variables loaded from dotenv
-# Force regenerate Prisma client with correct binary target
-RUN bash -c 'set -a && source .env && set +a && npx prisma generate && npm run build'
+# Build without database operations - only generate Prisma client and build Next.js
+RUN bash -c 'set -a && source .env && set +a && npm run build:simple'
 
 ###############################################################################################
 # Database initialization image (has access to ts-node and dev dependencies)

--- a/apps/webapp/init.sh
+++ b/apps/webapp/init.sh
@@ -4,5 +4,10 @@ set -a
 source .env
 set +a
 
+# Wait for database to be ready and run database operations at runtime
+echo "Waiting for database and running Prisma db push..."
+./node_modules/.bin/prisma db push
+
 # Start the Next.js application
+echo "Starting Next.js application..."
 node server.js


### PR DESCRIPTION
Addresses https://github.com/mitre/neuronpedia/issues/6

The webapp Docker build was failing because `npm run build` tries to connect to the database during the build process, which isn't available in the Docker build context. This moves database operations (`prisma db push`) to runtime and uses the local Prisma binary to prevent version mismatches that were causing query engine crashes.

**Changes:**
- Use `npm run build:simple` in Dockerfile (no database dependency)
- Run `prisma db push` at container startup in `init.sh`
- Use `./node_modules/.bin/prisma` instead of `npx` for version consistency

This follows standard Docker practices by keeping the build step stateless and deferring database interactions until runtime when containers can communicate.