### PR TITLE
Refactor Inference Dockerfile to Work in Zero Trust Environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ inference-localhost-install: ## Inference: Localhost Environment - Install Depen
 
 inference-localhost-build: ## Inference: Localhost Environment - Build
 	@echo "Building the inference server for the localhost environment..."
+	CUSTOM_CA_BUNDLE=$(CUSTOM_CA_BUNDLE) \
 	ENV_FILE=../.env.localhost \
 		BUILD_TYPE=$(BUILD_TYPE) \
 		docker compose \

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ inference-localhost-build: ## Inference: Localhost Environment - Build
 		build inference
 
 inference-localhost-build-gpu: ## Inference: Localhost Environment - Build (CUDA). Usage: make inference-localhost-build-gpu [USE_LOCAL_HF_CACHE=1]
-	$(MAKE) inference-localhost-build BUILD_TYPE=cuda
+	$(MAKE) inference-localhost-build BUILD_TYPE=cuda CUSTOM_CA_BUNDLE=$(CUSTOM_CA_BUNDLE)
 
 inference-localhost-dev: ## Inference: Localhost Environment - Run (Development Build). Usage: make inference-localhost-dev [MODEL_SOURCESET=gpt2-small.res-jb] [AUTORELOAD=1]
 	@echo "Bringing up the inference server for development in the localhost environment..."

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ reset-docker-data: ## Reset Docker Data - this deletes your local database!
 		exit 1; \
 	fi
 	@echo "Resetting Docker data..."
-	docker compose -f docker/compose.yaml down -v
+	ENV_FILE=../.env.localhost docker compose -f docker/compose.yaml down -v
 
 graph-localhost-install: ## Graph: Localhost Environment - Install Dependencies (Development Build)
 	@echo "Installing the graph server dependencies for development in the localhost environment..."

--- a/apps/inference/Dockerfile
+++ b/apps/inference/Dockerfile
@@ -31,6 +31,11 @@ WORKDIR /app
 
 ENV HOST=0.0.0.0
 
+# Optional custom CA bundle file support
+ARG CUSTOM_CA_BUNDLE
+# Copy the CA bundle file if provided, otherwise copy nothing (using .nocustomca as a no-op)
+COPY ${CUSTOM_CA_BUNDLE:-.nocustomca} /tmp/ca-bundle-temp
+
 # Ignore hash sum mismatch for apt-get
 RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
     echo "Acquire::http::No-Cache true;" >> /etc/apt/apt.conf.d/99custom && \
@@ -42,13 +47,36 @@ RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     make \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# Set up CA certificates and environment if bundle was provided
+RUN if [ -f /tmp/ca-bundle-temp ] && [ "${CUSTOM_CA_BUNDLE}" != ".nocustomca" ]; then \
+    mkdir -p /usr/local/share/ca-certificates && \
+    mv /tmp/ca-bundle-temp /usr/local/share/ca-certificates/custom-ca.crt && \
+    cat /usr/local/share/ca-certificates/custom-ca.crt >> /etc/ssl/certs/ca-certificates.crt && \
+    update-ca-certificates; \
+    else \
+    rm -f /tmp/ca-bundle-temp; \
+    fi
+
+# Set SSL environment variables if CA bundle was provided
+ENV SSL_CERT_FILE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV REQUESTS_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV CURL_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV GIT_SSL_CAINFO=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
 
 # Install poetry
 RUN pip install poetry
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 RUN poetry config virtualenvs.create false
+
+# Configure poetry/pip to use custom CA if provided
+RUN if [ -n "${CUSTOM_CA_BUNDLE}" ] && [ "${CUSTOM_CA_BUNDLE}" != ".nocustomca" ]; then \
+    pip config set global.cert /etc/ssl/certs/ca-certificates.crt && \
+    poetry config certificates.default.cert /etc/ssl/certs/ca-certificates.crt; \
+    fi
 
 # Copy the client package first
 COPY packages/python/neuronpedia-inference-client /app/packages/python/neuronpedia-inference-client/

--- a/apps/inference/Dockerfile
+++ b/apps/inference/Dockerfile
@@ -2,20 +2,74 @@ ARG BUILD_TYPE
 ARG CUDA_VERSION=12.1.0
 ARG UBUNTU_VERSION=22.04
 
+# Optional custom CA bundle file support
+ARG CUSTOM_CA_BUNDLE
+
 # NON-CUDA base
 FROM python:3.10-slim AS base-nocuda
 
+# Re-declare ARG after FROM (ARGs don't persist across FROM statements)
+ARG CUSTOM_CA_BUNDLE
+
+# Copy the CA bundle file if provided, otherwise copy nothing (using .nocustomca as a no-op)
+COPY ${CUSTOM_CA_BUNDLE:-.nocustomca} /tmp/ca-bundle-temp
+
+# Set up CA certificates and environment if bundle was provided
+RUN if [ -f /tmp/ca-bundle-temp ] && [ "${CUSTOM_CA_BUNDLE}" != ".nocustomca" ]; then \
+    apt-get update && apt-get install -y ca-certificates && \
+    mkdir -p /usr/local/share/ca-certificates && \
+    mv /tmp/ca-bundle-temp /usr/local/share/ca-certificates/custom-ca.crt && \
+    cat /usr/local/share/ca-certificates/custom-ca.crt >> /etc/ssl/certs/ca-certificates.crt && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*; \
+    else \
+    rm -f /tmp/ca-bundle-temp; \
+    fi
+
+# Set SSL environment variables if CA bundle was provided
+ENV SSL_CERT_FILE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV REQUESTS_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV CURL_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV GIT_SSL_CAINFO=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+
 # CUDA base
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION} AS base-cuda
-# Nvidia container toolkit
+
+# Re-declare ARG after FROM (ARGs don't persist across FROM statements)
+ARG CUSTOM_CA_BUNDLE
+
+# Copy the CA bundle file if provided, otherwise copy nothing (using .nocustomca as a no-op)
+COPY ${CUSTOM_CA_BUNDLE:-.nocustomca} /tmp/ca-bundle-temp
+
+# Install dependencies and set up CA certificates, then download NVIDIA toolkit
+RUN apt-get update && apt-get install -y curl gpg ca-certificates && \
+    if [ -f /tmp/ca-bundle-temp ] && [ "${CUSTOM_CA_BUNDLE}" != ".nocustomca" ]; then \
+        mkdir -p /usr/local/share/ca-certificates && \
+        mv /tmp/ca-bundle-temp /usr/local/share/ca-certificates/custom-ca.crt && \
+        cat /usr/local/share/ca-certificates/custom-ca.crt >> /etc/ssl/certs/ca-certificates.crt && \
+        update-ca-certificates && \
+        export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt && \
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && \
+        curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+        sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+        tee /etc/apt/sources.list.d/nvidia-container-toolkit.list; \
+    else \
+        rm -f /tmp/ca-bundle-temp && \
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && \
+        curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+        sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+        tee /etc/apt/sources.list.d/nvidia-container-toolkit.list; \
+    fi && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set SSL environment variables if CA bundle was provided
+ENV SSL_CERT_FILE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV REQUESTS_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV CURL_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
+ENV GIT_SSL_CAINFO=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
 RUN apt-get update && apt-get install -y \
-    curl gpg
-RUN curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-    && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
-    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-RUN apt-get update && apt-get install -y \
-    nvidia-container-toolkit
+    nvidia-container-toolkit \
+    && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y \
     python3.10 \
     python3-pip \
@@ -31,10 +85,8 @@ WORKDIR /app
 
 ENV HOST=0.0.0.0
 
-# Optional custom CA bundle file support
+# Optional custom CA bundle file support (re-declare for final stage)
 ARG CUSTOM_CA_BUNDLE
-# Copy the CA bundle file if provided, otherwise copy nothing (using .nocustomca as a no-op)
-COPY ${CUSTOM_CA_BUNDLE:-.nocustomca} /tmp/ca-bundle-temp
 
 # Ignore hash sum mismatch for apt-get
 RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
@@ -49,22 +101,6 @@ RUN apt-get update && apt-get install -y \
     make \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-
-# Set up CA certificates and environment if bundle was provided
-RUN if [ -f /tmp/ca-bundle-temp ] && [ "${CUSTOM_CA_BUNDLE}" != ".nocustomca" ]; then \
-    mkdir -p /usr/local/share/ca-certificates && \
-    mv /tmp/ca-bundle-temp /usr/local/share/ca-certificates/custom-ca.crt && \
-    cat /usr/local/share/ca-certificates/custom-ca.crt >> /etc/ssl/certs/ca-certificates.crt && \
-    update-ca-certificates; \
-    else \
-    rm -f /tmp/ca-bundle-temp; \
-    fi
-
-# Set SSL environment variables if CA bundle was provided
-ENV SSL_CERT_FILE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
-ENV REQUESTS_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
-ENV CURL_CA_BUNDLE=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
-ENV GIT_SSL_CAINFO=${CUSTOM_CA_BUNDLE:+/etc/ssl/certs/ca-certificates.crt}
 
 # Install poetry
 RUN pip install poetry

--- a/apps/webapp/Dockerfile
+++ b/apps/webapp/Dockerfile
@@ -60,9 +60,8 @@ RUN chmod +x ./init.sh
 ARG ENV_FILE=.env.localhost
 COPY ${ENV_FILE} .env
 
-# Build with environment variables loaded from dotenv
-# Force regenerate Prisma client with correct binary target
-RUN bash -c 'set -a && source .env && set +a && npx prisma generate && npm run build'
+# Build without database operations - only generate Prisma client and build Next.js
+RUN bash -c 'set -a && source .env && set +a && npm run build:simple'
 
 ###############################################################################################
 # Database initialization image (has access to ts-node and dev dependencies)

--- a/apps/webapp/init.sh
+++ b/apps/webapp/init.sh
@@ -4,5 +4,10 @@ set -a
 source .env
 set +a
 
+# Wait for database to be ready and run database operations at runtime
+echo "Waiting for database and running Prisma db push..."
+./node_modules/.bin/prisma db push
+
 # Start the Next.js application
+echo "Starting Next.js application..."
 node server.js

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -67,6 +67,7 @@ services:
         BUILD_TYPE: ${BUILD_TYPE:-nocuda} # Use nocuda by default, override with BUILD_TYPE=cuda
         CUDA_VERSION: "12.1.0"
         UBUNTU_VERSION: "22.04"
+        CUSTOM_CA_BUNDLE: ${CUSTOM_CA_BUNDLE:-./docker/.nocustomca}
     ports:
       - "5002:5002"
     env_file:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -9,7 +9,7 @@ services:
       target: runner
       args:
         ENV_FILE: ${ENV_FILE:-.env.localhost}
-        CUSTOM_CA_BUNDLE: ${CUSTOM_CA_BUNDLE:-./docker/.nocustomca}
+        CUSTOM_CA_BUNDLE: ${CUSTOM_CA_BUNDLE:-.nocustomca}
     ports:
       - "3000:3000"
     env_file:
@@ -26,7 +26,7 @@ services:
       target: db-init
       args:
         ENV_FILE: ${ENV_FILE:-.env.localhost}
-        CUSTOM_CA_BUNDLE: ${CUSTOM_CA_BUNDLE:-.docker/.nocustomca}
+        CUSTOM_CA_BUNDLE: ${CUSTOM_CA_BUNDLE:-.nocustomca}
     restart: "no"
     environment:
       - POSTGRES_URL_NON_POOLING=${POSTGRES_URL_NON_POOLING}
@@ -67,7 +67,7 @@ services:
         BUILD_TYPE: ${BUILD_TYPE:-nocuda} # Use nocuda by default, override with BUILD_TYPE=cuda
         CUDA_VERSION: "12.1.0"
         UBUNTU_VERSION: "22.04"
-        CUSTOM_CA_BUNDLE: ${CUSTOM_CA_BUNDLE:-./docker/.nocustomca}
+        CUSTOM_CA_BUNDLE: ${CUSTOM_CA_BUNDLE:-.nocustomca}
     ports:
       - "5002:5002"
     env_file:


### PR DESCRIPTION
### Problem

Currently, the inference service cannot build or run in zero trust environments because its Dockerfile does not support setting custom CA bundles.

- Refactors `apps/inference/Dockerfile` to support setting `CUSTOM_CA_BUNDLE` (adapted the same workflow present in `apps/webapp/Dockerfile`)
- Notably, this PR also includes a hot-fix commit cherry-picked from https://github.com/hijohnnylin/neuronpedia/pull/168, which resolves an issue with the webapp's Docker build process. Technically, that PR should be merged first.

### Fix 

- Refactors `apps/inference/Dockerfile` and `Makefile` to support *optionally* setting environment variable `CUSTOM_CA_BUNDLE` for building and running the Neuronpedia Inference service in zero-trust environments (i.e., Zscaler) where custom/self-signed certificate chains must be injected into the SSL resolution chain of networking tools in order for SSL verification to pass. 
 
### Testing

The following commands work in a zero-trust environment:

- `make inference-localhost-build CUSTOM_CA_BUNDLE=path/to/crt/file`
- `make inference-localhost-build-gpu CUSTOM_CA_BUNDLE=path/to/crt/file`
- `make inference-localhost-dev CUSTOM_CA_BUNDLE=path/to/crt/file`

I was able to bring the inference service up and search via inference:

<img width="2064" height="155" alt="image" src="https://github.com/user-attachments/assets/019fa362-8822-474c-87ad-79ad0d37cdc1" />

<img width="1597" height="1101" alt="image" src="https://github.com/user-attachments/assets/b136475c-205a-400e-abfd-1aca5a5e8cef" />
