### PR TITLE
Trailing space on makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ reset-docker-data: ## Reset Docker Data - this deletes your local database!
 
 graph-localhost-install: ## Graph: Localhost Environment - Install Dependencies (Development Build)
 	@echo "Installing the graph server dependencies for development in the localhost environment..."
-	cd apps/graph && \	
+	cd apps/graph && \
 	poetry lock && poetry install
 
 


### PR DESCRIPTION
### Problem

There was a trailing space in make command for downloading graph dependencies on local:

```
 neuronpedia git:(debug-issue-167) ✗ make graph-localhost-install
Installing the graph server dependencies for development in the localhost environment...
cd apps/graph && \
/bin/sh: 	: command not found
make: *** [graph-localhost-install] Error 127
```