### PR TITLE
Add an animated "Field" view to the Jacobian Lens explorer

### DIFF
--- a/apps/webapp/components/jlens/__tests__/jlens-field-sim.test.ts
+++ b/apps/webapp/components/jlens/__tests__/jlens-field-sim.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from 'vitest';
+import type { LensTokenMessage } from '@/lib/utils/lens';
+import {
+  buildFieldSteps,
+  cleanLabel,
+  conceptsForToken,
+  DEFAULT_FIELD_CONFIG,
+  FieldConfig,
+  FieldSim,
+  hasAnyConcepts,
+  isJunkToken,
+  normalizeKey,
+  rampColor,
+} from '../jlens-field-sim';
+
+// Build a single-lens token whose per-layer read-outs are the same rows on every
+// layer, so tests can reason about the layer window and weighting directly.
+function makeToken(
+  token: string,
+  rows: { tokens: string[]; probs: number[] }[],
+  opts: { position?: number; isGenerated?: boolean; type?: 'JACOBIAN_LENS' | 'LOGIT_LENS' } = {},
+): LensTokenMessage {
+  return {
+    kind: 'token',
+    position: opts.position ?? 0,
+    token,
+    id: opts.position ?? 0,
+    is_generated: opts.isGenerated ?? true,
+    results: [
+      {
+        type: opts.type ?? 'JACOBIAN_LENS',
+        top_tokens: rows.map((r) => r.tokens),
+        top_probs: rows.map((r) => r.probs),
+      },
+    ],
+  };
+}
+
+const cfg = (over: Partial<FieldConfig> = {}): FieldConfig => ({ ...DEFAULT_FIELD_CONFIG, ...over });
+
+describe('isJunkToken', () => {
+  test('filters whitespace, punctuation, specials, single ascii, replacement char', () => {
+    expect(isJunkToken('   ')).toBe(true);
+    expect(isJunkToken('...')).toBe(true);
+    expect(isJunkToken('<|endoftext|>')).toBe(true);
+    expect(isJunkToken('a')).toBe(true);
+    expect(isJunkToken('�')).toBe(true);
+  });
+
+  test('keeps real words and CJK tokens', () => {
+    expect(isJunkToken(' Rayleigh')).toBe(false);
+    expect(isJunkToken('scattering')).toBe(false);
+    expect(isJunkToken('色散')).toBe(false);
+  });
+});
+
+describe('normalizeKey / cleanLabel', () => {
+  test('strips tokenizer boundary markers and lowercases the key', () => {
+    expect(normalizeKey('ĠRayleigh')).toBe('rayleigh');
+    expect(normalizeKey('▁blue')).toBe('blue');
+    expect(normalizeKey('  Blue ')).toBe('blue');
+  });
+
+  test('cleanLabel strips markers but keeps case', () => {
+    expect(cleanLabel('ĠRayleigh')).toBe('Rayleigh');
+    expect(cleanLabel('▁Blue')).toBe('Blue');
+  });
+});
+
+describe('rampColor', () => {
+  test('returns the ramp endpoints and clamps out-of-range input', () => {
+    expect(rampColor(0)).toEqual([148, 163, 184]);
+    expect(rampColor(1)).toEqual([245, 158, 11]);
+    expect(rampColor(-1)).toEqual(rampColor(0));
+    expect(rampColor(2)).toEqual(rampColor(1));
+  });
+});
+
+describe('conceptsForToken', () => {
+  test('reads only layers above the start fraction and weights later layers more', () => {
+    // 4 layers; layerStartFraction 0.5 -> cut at layer 2, so layers 0/1 ignored.
+    const token = makeToken(' output', [
+      { tokens: [' noiseA'], probs: [0.9] }, // layer 0, ignored
+      { tokens: [' noiseB'], probs: [0.9] }, // layer 1, ignored
+      { tokens: [' Rayleigh'], probs: [0.4] }, // layer 2, ramp 0
+      { tokens: [' Rayleigh'], probs: [0.5] }, // layer 3, ramp 1
+    ]);
+    const concepts = conceptsForToken(token, cfg({ layerStartFraction: 0.5 }));
+    const keys = concepts.map((c) => c.key);
+    expect(keys).toContain('rayleigh');
+    expect(keys).not.toContain('noisea');
+    expect(keys).not.toContain('noiseb');
+    const rayleigh = concepts.find((c) => c.key === 'rayleigh')!;
+    // Peak probability/layer is the strongest layer for the concept.
+    expect(rayleigh.peakProb).toBeCloseTo(0.5, 6);
+    expect(rayleigh.peakLayer).toBe(3);
+  });
+
+  test('drops junk, sub-threshold probs, and (optionally) the emitted token', () => {
+    const token = makeToken(' blue', [
+      { tokens: [' blue', ' ...', ' tiny'], probs: [0.5, 0.5, 0.001] },
+      { tokens: [' blue', ' scattering', ' tiny'], probs: [0.5, 0.4, 0.001] },
+    ]);
+    const withEmitted = conceptsForToken(token, cfg({ layerStartFraction: 0, hideEmitted: false }));
+    expect(withEmitted.map((c) => c.key)).toContain('blue');
+    expect(withEmitted.map((c) => c.key)).not.toContain('...'); // punctuation filtered
+    expect(withEmitted.map((c) => c.key)).not.toContain('tiny'); // below prob floor
+
+    const hidden = conceptsForToken(token, cfg({ layerStartFraction: 0, hideEmitted: true }));
+    expect(hidden.map((c) => c.key)).not.toContain('blue'); // emitted token hidden
+    expect(hidden.map((c) => c.key)).toContain('scattering');
+  });
+
+  test('returns concepts sorted by descending weight', () => {
+    const token = makeToken(' x', [
+      { tokens: [' weak', ' strong'], probs: [0.05, 0.6] },
+      { tokens: [' weak', ' strong'], probs: [0.05, 0.6] },
+    ]);
+    const concepts = conceptsForToken(token, cfg({ layerStartFraction: 0 }));
+    expect(concepts[0].key).toBe('strong');
+    for (let i = 1; i < concepts.length; i++) {
+      expect(concepts[i - 1].weight).toBeGreaterThanOrEqual(concepts[i].weight);
+    }
+  });
+});
+
+describe('buildFieldSteps / hasAnyConcepts', () => {
+  const rows = [
+    { tokens: [' Rayleigh'], probs: [0.4] },
+    { tokens: [' Rayleigh'], probs: [0.5] },
+  ];
+
+  test('produces one step per token and reports concept presence', () => {
+    const tokens = [makeToken(' a', rows, { position: 0 }), makeToken(' b', rows, { position: 1 })];
+    const steps = buildFieldSteps(tokens, cfg({ layerStartFraction: 0 }));
+    expect(steps).toHaveLength(2);
+    expect(hasAnyConcepts(steps)).toBe(true);
+  });
+
+  test('reports no concepts when everything is junk', () => {
+    const junk = [makeToken(' a', [{ tokens: [' ...'], probs: [0.9] }], { position: 0 })];
+    const steps = buildFieldSteps(junk, cfg({ layerStartFraction: 0 }));
+    expect(hasAnyConcepts(steps)).toBe(false);
+  });
+});
+
+describe('FieldSim', () => {
+  const bounds = { x0: 0, y0: 0, x1: 400, y1: 300 };
+  const rows = [
+    { tokens: [' Rayleigh', ' scattering'], probs: [0.4, 0.3] },
+    { tokens: [' Rayleigh', ' scattering'], probs: [0.5, 0.35] },
+  ];
+  const steps = buildFieldSteps(
+    Array.from({ length: 6 }, (_, i) => makeToken(' t', rows, { position: i })),
+    cfg({ layerStartFraction: 0 }),
+  );
+
+  test('is deterministic: two sims seeked to the same time match exactly', () => {
+    const a = new FieldSim(steps, cfg(), bounds);
+    const b = new FieldSim(steps, cfg(), bounds);
+    a.seek(3);
+    b.seek(3);
+    const keysA = [...a.bubbles.keys()].sort();
+    const keysB = [...b.bubbles.keys()].sort();
+    expect(keysA).toEqual(keysB);
+    for (const k of keysA) {
+      expect(a.bubbles.get(k)!.x).toBeCloseTo(b.bubbles.get(k)!.x, 9);
+      expect(a.bubbles.get(k)!.y).toBeCloseTo(b.bubbles.get(k)!.y, 9);
+      expect(a.bubbles.get(k)!.energy).toBeCloseTo(b.bubbles.get(k)!.energy, 9);
+    }
+  });
+
+  test('seeking backward replays from the start (same state as a fresh seek)', () => {
+    const a = new FieldSim(steps, cfg(), bounds);
+    a.seek(3);
+    a.seek(1);
+    const b = new FieldSim(steps, cfg(), bounds);
+    b.seek(1);
+    expect([...a.bubbles.keys()].sort()).toEqual([...b.bubbles.keys()].sort());
+    for (const k of a.bubbles.keys()) {
+      expect(a.bubbles.get(k)!.x).toBeCloseTo(b.bubbles.get(k)!.x, 9);
+    }
+  });
+
+  test('surfaces concepts and keeps bubbles within bounds', () => {
+    const sim = new FieldSim(steps, cfg(), bounds);
+    sim.seek(2);
+    expect(sim.bubbles.size).toBeGreaterThan(0);
+    for (const b of sim.bubbles.values()) {
+      expect(b.x).toBeGreaterThanOrEqual(bounds.x0 - 1);
+      expect(b.x).toBeLessThanOrEqual(bounds.x1 + 1);
+      expect(b.y).toBeGreaterThanOrEqual(bounds.y0 - 1);
+      expect(b.y).toBeLessThanOrEqual(bounds.y1 + 1);
+    }
+  });
+
+  test('has a positive duration and a clamped token counter', () => {
+    const sim = new FieldSim(steps, cfg(), bounds);
+    expect(sim.duration).toBeGreaterThan(0);
+    expect(sim.stepCount).toBe(6);
+    expect(sim.tokenIndexAt(-5)).toBe(0);
+    expect(sim.tokenIndexAt(sim.duration + 100)).toBe(6);
+  });
+});

--- a/apps/webapp/components/jlens/jlens-chat.tsx
+++ b/apps/webapp/components/jlens/jlens-chat.tsx
@@ -44,7 +44,8 @@ import {
   JlensExportSteer,
   parseFixture,
 } from './jlens-export';
-import { LensModeSetContext } from './jlens-lens-mode';
+import JlensField, { JlensLeftView, JlensViewToggle } from './jlens-field';
+import { LensModeSetContext, lensTypesForMode } from './jlens-lens-mode';
 import { JlensShareDialog } from './jlens-share-dialog';
 import { DefaultOutputHeader, SteerOutputHeader } from './jlens-steer-panel';
 import { runLensStream as baseRunLensStream, RunLensStreamParams } from './jlens-stream';
@@ -210,6 +211,11 @@ export default function JlensChat({
   // The in-flight steered run's abort controller.
   const steerAbortRef = useRef<AbortController | null>(null);
   const steering = analysis.steer != null;
+
+  // Whether the left panel shows the token transcript or the animated field.
+  const [leftView, setLeftView] = useState<JlensLeftView>('default');
+  // DIFF has no single read-out direction; fall back to its first lens type.
+  const fieldLensType = lensTypesForMode(lensMode)[0];
   // A steered run restored from a shared link, applied once the main tokens have
   // been hydrated (so the steer panel's per-layer counts compute correctly).
   const pendingSteerRef = useRef<JlensExportSteer | null>(null);
@@ -1449,41 +1455,50 @@ export default function JlensChat({
                     />
                   </div>
                 )}
-                <div
-                  ref={scrollRef}
-                  id={JLENS_STEER_COLUMNS_ID}
-                  onPointerDown={isEditing || steering ? undefined : onChatPointerDown}
-                  className={`min-h-0 flex-1 overflow-y-auto ${dragging ? 'select-none' : ''}`}
-                >
-                  {/* Inner row is `min-h-full` so it grows to the taller of the
+                {!steering && tokens.length > 0 && (
+                  <div className="mb-2 mt-1 flex flex-row items-center justify-end px-2 sm:px-4">
+                    <JlensViewToggle view={leftView} onChange={setLeftView} defaultLabel="Chat" />
+                  </div>
+                )}
+                {leftView === 'field' && !steering ? (
+                  <JlensField tokens={tokens} lensType={fieldLensType} className="px-2 pb-2 sm:px-4" />
+                ) : (
+                  <div
+                    ref={scrollRef}
+                    id={JLENS_STEER_COLUMNS_ID}
+                    onPointerDown={isEditing || steering ? undefined : onChatPointerDown}
+                    className={`min-h-0 flex-1 overflow-y-auto ${dragging ? 'select-none' : ''}`}
+                  >
+                    {/* Inner row is `min-h-full` so it grows to the taller of the
                       viewport and the scrolled content — otherwise the steered
                       column's divider (align-stretch) would only span the first
                       visible page and stop mid-transcript when scrolled. */}
-                  <div className="flex min-h-full flex-row gap-x-0 gap-y-2.5">
-                    {steering ? (
-                      <div className="sm:min-w-auto mt-1 flex flex-1 flex-col gap-y-2.5 px-2 sm:px-0 sm:pt-2">
-                        <DefaultOutputHeader />
-                        {defaultMessages}
-                      </div>
-                    ) : (
-                      <div
-                        id={JLENS_CHAT_ID}
-                        className="flex min-h-0 flex-1 flex-col gap-y-2.5 px-2 pt-2 sm:px-4 sm:pt-4"
-                      >
-                        {defaultMessages}
-                      </div>
-                    )}
-                    {analysis.steer && (
-                      <div
-                        id={JLENS_STEER_OUTPUT_ID}
-                        className="sm:min-w-auto mt-1 flex flex-1 flex-col gap-y-2.5 border-l border-slate-300 px-2 sm:ml-4 sm:pl-4 sm:pt-2"
-                      >
-                        <SteerOutputHeader steer={analysis.steer} />
-                        {renderSteerResults()}
-                      </div>
-                    )}
+                    <div className="flex min-h-full flex-row gap-x-0 gap-y-2.5">
+                      {steering ? (
+                        <div className="sm:min-w-auto mt-1 flex flex-1 flex-col gap-y-2.5 px-2 sm:px-0 sm:pt-2">
+                          <DefaultOutputHeader />
+                          {defaultMessages}
+                        </div>
+                      ) : (
+                        <div
+                          id={JLENS_CHAT_ID}
+                          className="flex min-h-0 flex-1 flex-col gap-y-2.5 px-2 pt-2 sm:px-4 sm:pt-4"
+                        >
+                          {defaultMessages}
+                        </div>
+                      )}
+                      {analysis.steer && (
+                        <div
+                          id={JLENS_STEER_OUTPUT_ID}
+                          className="sm:min-w-auto mt-1 flex flex-1 flex-col gap-y-2.5 border-l border-slate-300 px-2 sm:ml-4 sm:pl-4 sm:pt-2"
+                        >
+                          <SteerOutputHeader steer={analysis.steer} />
+                          {renderSteerResults()}
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
+                )}
 
                 {error && (
                   <div className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[11px] text-red-700">

--- a/apps/webapp/components/jlens/jlens-completion.tsx
+++ b/apps/webapp/components/jlens/jlens-completion.tsx
@@ -29,7 +29,8 @@ import {
   JlensExportCompletion,
   JlensExportSteer,
 } from './jlens-export';
-import { LensModeSetContext } from './jlens-lens-mode';
+import JlensField, { JlensLeftView, JlensViewToggle } from './jlens-field';
+import { LensModeSetContext, lensTypesForMode } from './jlens-lens-mode';
 import { JlensShareDialog } from './jlens-share-dialog';
 import { DefaultOutputHeader, SteerOutputHeader } from './jlens-steer-panel';
 import { runLensStream as baseRunLensStream, RunLensStreamParams } from './jlens-stream';
@@ -155,6 +156,11 @@ export default function JlensCompletion({
     handleTokenHover,
     bandsByPosition,
   } = analysis;
+
+  // Whether the left panel shows the token transcript or the animated field.
+  const [leftView, setLeftView] = useState<JlensLeftView>('default');
+  // DIFF has no single read-out direction; fall back to its first lens type.
+  const fieldLensType = lensTypesForMode(lensMode)[0];
 
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -948,41 +954,51 @@ export default function JlensCompletion({
                   </div>
                 )}
 
-                <div
-                  ref={scrollRef}
-                  onPointerDown={steering ? undefined : onChatPointerDown}
-                  className={`mt-2 min-h-0 flex-1 overflow-y-auto ${dragging ? 'select-none' : ''}`}
-                >
-                  {/* Inner row is `min-h-full` so it grows to the taller of the
+                {hasRun && !steering && tokens.length > 0 && (
+                  <div className="mt-2 flex flex-row items-center justify-end px-1">
+                    <JlensViewToggle view={leftView} onChange={setLeftView} defaultLabel="Tokens" />
+                  </div>
+                )}
+
+                {leftView === 'field' && !steering && hasRun ? (
+                  <JlensField tokens={tokens} lensType={fieldLensType} className="mt-2" />
+                ) : (
+                  <div
+                    ref={scrollRef}
+                    onPointerDown={steering ? undefined : onChatPointerDown}
+                    className={`mt-2 min-h-0 flex-1 overflow-y-auto ${dragging ? 'select-none' : ''}`}
+                  >
+                    {/* Inner row is `min-h-full` so it grows to the taller of the
                       viewport and the scrolled content — otherwise the steered
                       column's divider (align-stretch) would only span the first
                       visible page and stop mid-transcript when scrolled. */}
-                  <div className="flex min-h-full flex-row gap-x-0 gap-y-2.5">
-                    {hasRun ? (
-                      <>
-                        {steering ? (
-                          <div className="sm:min-w-auto mt-1 flex flex-1 flex-col gap-y-2.5">
-                            <DefaultOutputHeader />
-                            {defaultOutput}
-                          </div>
-                        ) : (
-                          <div className="flex min-h-0 flex-1 flex-col gap-y-2.5">{defaultOutput}</div>
-                        )}
-                        {analysis.steer && (
-                          <div className="sm:min-w-auto ml-4 mt-1 flex flex-1 flex-col gap-y-2.5 border-l border-slate-300 pl-4">
-                            <SteerOutputHeader steer={analysis.steer} />
-                            {renderSteerResults()}
-                          </div>
-                        )}
-                      </>
-                    ) : (
-                      <div className="flex max-h-[64px] w-full items-center gap-x-2 self-start rounded-xl bg-white px-4 py-3 text-slate-400 shadow">
-                        <LoadingSquare size={16} />
-                        <span className="text-[13px]">Generating…</span>
-                      </div>
-                    )}
+                    <div className="flex min-h-full flex-row gap-x-0 gap-y-2.5">
+                      {hasRun ? (
+                        <>
+                          {steering ? (
+                            <div className="sm:min-w-auto mt-1 flex flex-1 flex-col gap-y-2.5">
+                              <DefaultOutputHeader />
+                              {defaultOutput}
+                            </div>
+                          ) : (
+                            <div className="flex min-h-0 flex-1 flex-col gap-y-2.5">{defaultOutput}</div>
+                          )}
+                          {analysis.steer && (
+                            <div className="sm:min-w-auto ml-4 mt-1 flex flex-1 flex-col gap-y-2.5 border-l border-slate-300 pl-4">
+                              <SteerOutputHeader steer={analysis.steer} />
+                              {renderSteerResults()}
+                            </div>
+                          )}
+                        </>
+                      ) : (
+                        <div className="flex max-h-[64px] w-full items-center gap-x-2 self-start rounded-xl bg-white px-4 py-3 text-slate-400 shadow">
+                          <LoadingSquare size={16} />
+                          <span className="text-[13px]">Generating…</span>
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
+                )}
               </>
             ) : (
               <div className="flex flex-1 flex-col items-center justify-center gap-y-3 px-1">

--- a/apps/webapp/components/jlens/jlens-field-sim.ts
+++ b/apps/webapp/components/jlens/jlens-field-sim.ts
@@ -1,0 +1,492 @@
+// Pure simulation + parsing for the jlens "Field" view: a time-based, animated
+// reading of a run's lens read-outs. Each concept the lens surfaces becomes a
+// bubble whose size tracks the decode-probability mass it accumulates across
+// layers and whose colour tracks its salience relative to the strongest concept
+// on screen. The module is framework-free (no React, no DOM) and deterministic
+// so a scrubber can seek to any time by replaying from the start — this keeps it
+// unit-testable and keeps the React component thin.
+
+import type { LensTokenMessage, LensType, LensTypeSlice } from '@/lib/utils/lens';
+
+// Fixed simulation step. The sim is integrated at this rate regardless of the
+// display frame rate, so playback and seeks are frame-rate independent.
+export const FIELD_DT = 1 / 60;
+
+export interface FieldConfig {
+  // Which lens type's read-outs feed the field. DIFF has no single read-out
+  // direction of its own, so callers pass the concrete type to render (we fall
+  // back to the first available type per token).
+  lensType: LensType;
+  // Fraction of layers to discard from the bottom before reading concepts.
+  // Early layers are mostly token identity; meaning concentrates in the middle
+  // and late layers. Matches the explorer's START_LAYER_FRACTION trimming.
+  layerStartFraction: number;
+  // Seconds each token occupies on the timeline.
+  secondsPerToken: number;
+  // Time constant (seconds) for a concept's mass to decay without reinforcement.
+  decaySeconds: number;
+  // Most concurrent bubbles; the weakest are evicted first.
+  maxBubbles: number;
+  // Drop the concept that matches the token actually emitted, so the field
+  // shows context rather than the obvious next word.
+  hideEmitted: boolean;
+}
+
+export const DEFAULT_FIELD_CONFIG: FieldConfig = {
+  lensType: 'JACOBIAN_LENS',
+  layerStartFraction: 0.5,
+  secondsPerToken: 0.32,
+  decaySeconds: 5,
+  maxBubbles: 48,
+  hideEmitted: true,
+};
+
+export interface FieldConcept {
+  key: string;
+  label: string;
+  // Accumulated, layer-weighted decode-probability mass for this token.
+  weight: number;
+  // Layer index and probability where this concept decodes strongest.
+  peakLayer: number;
+  peakProb: number;
+}
+
+export interface FieldStep {
+  position: number;
+  isGenerated: boolean;
+  concepts: FieldConcept[];
+}
+
+export interface FieldBubble {
+  key: string;
+  label: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  // Current (decayed) mass.
+  energy: number;
+  // Current rendered radius.
+  radius: number;
+  // Sim time this bubble was born, for the fade-in.
+  born: number;
+  // Reinforcement flash (0..1), decays quickly after each new injection.
+  boost: number;
+  peakLayer: number;
+  peakProb: number;
+  // Token position that first surfaced this concept (-1 while unseen).
+  firstPosition: number;
+  // Per-bubble phase offsets for the deterministic drift.
+  driftX: number;
+  driftY: number;
+}
+
+export interface FieldBounds {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+// ---- small deterministic helpers ----
+
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export const clamp = (v: number, lo: number, hi: number) => (v < lo ? lo : v > hi ? hi : v);
+export const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+export const smoothstep = (t: number) => {
+  const c = clamp(t, 0, 1);
+  return c * c * (3 - 2 * c);
+};
+
+// Cool-to-hot ramp tuned for a light background: slate, then sky, indigo, and a
+// warm amber at the top end so the strongest concept reads as "hot" without the
+// dark-theme neon of the standalone tool.
+export const FIELD_RAMP: [number, [number, number, number]][] = [
+  [0.0, [148, 163, 184]], // slate-400
+  [0.35, [56, 189, 248]], // sky-400
+  [0.6, [79, 70, 229]], // indigo-600
+  [0.8, [217, 70, 239]], // fuchsia-500
+  [1.0, [245, 158, 11]], // amber-500
+];
+
+export function rampColor(f: number): [number, number, number] {
+  const x = clamp(f, 0, 1);
+  for (let i = 1; i < FIELD_RAMP.length; i++) {
+    if (x <= FIELD_RAMP[i][0]) {
+      const [f0, c0] = FIELD_RAMP[i - 1];
+      const [f1, c1] = FIELD_RAMP[i];
+      const t = (x - f0) / (f1 - f0 || 1);
+      return [Math.round(lerp(c0[0], c1[0], t)), Math.round(lerp(c0[1], c1[1], t)), Math.round(lerp(c0[2], c1[2], t))];
+    }
+  }
+  return FIELD_RAMP[FIELD_RAMP.length - 1][1];
+}
+
+// ---- token cleaning ----
+
+const PUNCT_ONLY = /^[\p{P}\p{S}\p{Z}\p{N}\p{C}\s]+$/u;
+const SPECIAL = /^<[^>]*>$/;
+
+// Whether a decoded token is not worth showing as a concept: empty, a special
+// marker, punctuation/whitespace only, a lone ascii char, or a decode-failure
+// replacement character. The explorer already filters non-word tokens
+// server-side by default; this keeps the field clean for exports that did not.
+export function isJunkToken(raw: string): boolean {
+  const k = raw.trim();
+  if (!k) return true;
+  if (k.includes('�')) return true;
+  if (SPECIAL.test(k)) return true;
+  if (PUNCT_ONLY.test(k)) return true;
+  if (k.length < 2 && k.charCodeAt(0) < 0x2e80) return true;
+  return false;
+}
+
+// Strip leading tokenizer word-boundary markers and normalize for de-duping.
+export function normalizeKey(raw: string): string {
+  return raw
+    .replace(/^[ĠĊ▁]+/, '')
+    .trim()
+    .toLowerCase();
+}
+
+// Display form: strip the boundary markers but keep the original case.
+export function cleanLabel(raw: string): string {
+  return raw.replace(/^[ĠĊ▁]+/, '').trim();
+}
+
+// Pick the read-out slice for the configured lens type, falling back to the
+// token's first slice (covers DIFF, where there is no single own direction).
+function sliceForToken(token: LensTokenMessage, lensType: LensType): LensTypeSlice | undefined {
+  const match = token.results.find((r) => r.type === lensType);
+  return match ?? token.results[0];
+}
+
+// Aggregate one token's per-layer read-outs into a ranked concept list.
+export function conceptsForToken(token: LensTokenMessage, config: FieldConfig): FieldConcept[] {
+  const slice = sliceForToken(token, config.lensType);
+  if (!slice || !Array.isArray(slice.top_tokens)) return [];
+
+  const layers = slice.top_tokens.length;
+  const cut = Math.floor(layers * config.layerStartFraction);
+  const span = layers - 1 - cut;
+  const emittedKey = normalizeKey(token.token);
+
+  const acc = new Map<string, FieldConcept & { bestWeight: number }>();
+  for (let l = cut; l < layers; l++) {
+    const row = slice.top_tokens[l];
+    const probs = slice.top_probs?.[l];
+    if (!row) continue;
+    // Later layers weigh more: their read-outs are closer to what gets said.
+    const ramp = span > 0 ? (l - cut) / span : 1;
+    for (let k = 0; k < row.length; k++) {
+      const p = probs ? probs[k] : 1 / (k + 2);
+      if (p < 0.004) continue;
+      const raw = row[k];
+      if (isJunkToken(raw)) continue;
+      const key = normalizeKey(raw);
+      if (config.hideEmitted && key === emittedKey) continue;
+      const w = p * ramp;
+      let e = acc.get(key);
+      if (!e) {
+        e = { key, label: cleanLabel(raw), weight: 0, peakLayer: -1, peakProb: 0, bestWeight: 0 };
+        acc.set(key, e);
+      }
+      e.weight += w;
+      if (w > e.bestWeight) {
+        e.bestWeight = w;
+        e.label = cleanLabel(raw);
+      }
+      if (p > e.peakProb) {
+        e.peakProb = p;
+        e.peakLayer = l;
+      }
+    }
+  }
+
+  const out: FieldConcept[] = [];
+  for (const e of acc.values()) {
+    if (e.weight >= 0.04) {
+      out.push({ key: e.key, label: e.label, weight: e.weight, peakLayer: e.peakLayer, peakProb: e.peakProb });
+    }
+  }
+  out.sort((a, b) => b.weight - a.weight);
+  return out.slice(0, 24);
+}
+
+// Build the per-token concept steps for a whole run.
+export function buildFieldSteps(tokens: LensTokenMessage[], config: FieldConfig): FieldStep[] {
+  return tokens.map((t) => ({
+    position: t.position,
+    isGenerated: t.is_generated,
+    concepts: conceptsForToken(t, config),
+  }));
+}
+
+// Whether a run has any renderable concepts at all under the given config, so
+// the UI can show an empty state instead of a blank canvas.
+export function hasAnyConcepts(steps: FieldStep[]): boolean {
+  return steps.some((s) => s.concepts.length > 0);
+}
+
+interface TimelineEvent {
+  time: number;
+  concepts: FieldConcept[];
+  position: number;
+}
+
+// Prompt read-outs count for less than generated ones: the field should be
+// driven by what the model is composing, not what it was given.
+const PROMPT_WEIGHT = 0.5;
+const GENERATED_WEIGHT = 1;
+// The concept flares a fraction of a token-step before its token lands.
+const LEAD_FRACTION = 0.55;
+
+// The deterministic bubble field. Construct with the run's steps + bounds, then
+// drive it with `tick(dt)` or jump to any time with `seek(t)` (which replays
+// from the start when moving backwards, keeping playback reproducible).
+export class FieldSim {
+  readonly duration: number;
+  // Number of tokens on the timeline (used for the "token i / N" counter).
+  readonly stepCount: number;
+  private readonly events: TimelineEvent[];
+  private readonly startTime = 0.6;
+  bubbles: Map<string, FieldBubble> = new Map();
+  time = 0;
+  energyMax = 1;
+
+  private eventIdx = 0;
+  private spawnCount = 0;
+  private rng: () => number = mulberry32(1337);
+
+  constructor(
+    steps: FieldStep[],
+    private readonly config: FieldConfig,
+    private bounds: FieldBounds,
+  ) {
+    this.events = [];
+    steps.forEach((step, i) => {
+      if (step.concepts.length === 0) return;
+      const time = Math.max(0.05, this.startTime + i * config.secondsPerToken - LEAD_FRACTION * config.secondsPerToken);
+      const mult = step.isGenerated ? GENERATED_WEIGHT : PROMPT_WEIGHT;
+      const concepts = step.concepts.map((c) => ({ ...c, weight: c.weight * mult }));
+      this.events.push({ time, concepts, position: step.position });
+    });
+    this.events.sort((a, b) => a.time - b.time);
+    this.stepCount = steps.length;
+    this.duration = this.startTime + steps.length * config.secondsPerToken + 2.5;
+    this.reset();
+  }
+
+  // 1-based ordinal of the token being read at time t (0 before the first),
+  // clamped to the run length. Drives the "token i / N" counter.
+  tokenIndexAt(t: number): number {
+    const idx = Math.floor((t - this.startTime) / this.config.secondsPerToken) + 1;
+    return clamp(idx, 0, this.stepCount);
+  }
+
+  setBounds(bounds: FieldBounds) {
+    this.bounds = bounds;
+  }
+
+  reset() {
+    this.time = 0;
+    this.eventIdx = 0;
+    this.spawnCount = 0;
+    this.rng = mulberry32(1337);
+    this.bubbles = new Map();
+    this.energyMax = 1;
+  }
+
+  private spawnPos(): [number, number] {
+    const b = this.bounds;
+    const cx = (b.x0 + b.x1) / 2;
+    const cy = (b.y0 + b.y1) / 2;
+    const n = this.spawnCount++;
+    // Golden-angle scatter so early bubbles fan out instead of stacking.
+    const ang = n * 2.39996 + this.rng() * 0.7;
+    const rad = (0.12 + 0.72 * Math.sqrt((n % 60) / 60)) * Math.min(b.x1 - b.x0, b.y1 - b.y0) * 0.5;
+    return [
+      cx + Math.cos(ang) * rad * 1.35 + (this.rng() - 0.5) * 30,
+      cy + Math.sin(ang) * rad + (this.rng() - 0.5) * 30,
+    ];
+  }
+
+  private inject(concepts: FieldConcept[], position: number) {
+    for (const c of concepts) {
+      let bub = this.bubbles.get(c.key);
+      if (!bub) {
+        if (this.bubbles.size >= this.config.maxBubbles) {
+          let weakestKey: string | null = null;
+          let weakest = Infinity;
+          for (const [k, b] of this.bubbles) {
+            if (b.energy < weakest) {
+              weakest = b.energy;
+              weakestKey = k;
+            }
+          }
+          if (weakest > c.weight * 1.5 || weakestKey === null) continue;
+          this.bubbles.delete(weakestKey);
+        }
+        const [x, y] = this.spawnPos();
+        bub = {
+          key: c.key,
+          label: c.label,
+          x,
+          y,
+          vx: 0,
+          vy: 0,
+          energy: 0,
+          radius: 0,
+          born: this.time,
+          boost: 0,
+          peakLayer: -1,
+          peakProb: 0,
+          firstPosition: position,
+          driftX: this.rng() * 1000,
+          driftY: this.rng() * 1000,
+        };
+        this.bubbles.set(c.key, bub);
+      }
+      bub.energy += c.weight;
+      bub.label = c.label;
+      if (c.peakProb > bub.peakProb) {
+        bub.peakProb = c.peakProb;
+        bub.peakLayer = c.peakLayer;
+      }
+      bub.boost = Math.min(1, bub.boost + clamp(c.weight * 2, 0.25, 1));
+    }
+  }
+
+  tick(dt: number = FIELD_DT) {
+    const next = this.time + dt;
+    while (this.eventIdx < this.events.length && this.events[this.eventIdx].time <= next) {
+      this.inject(this.events[this.eventIdx].concepts, this.events[this.eventIdx].position);
+      this.eventIdx++;
+    }
+    this.time = next;
+
+    const b = this.bounds;
+    const decayK = Math.exp(-dt / this.config.decaySeconds);
+    let em = 0.001;
+    for (const bub of this.bubbles.values()) if (bub.energy > em) em = bub.energy;
+    this.energyMax = Math.max(em, lerp(this.energyMax, em, 0.02), 0.6);
+
+    const arr = [...this.bubbles.values()];
+    const cx = (b.x0 + b.x1) / 2;
+    const cy = (b.y0 + b.y1) / 2;
+    const rMin = 10;
+    const rMax = Math.min(b.x1 - b.x0, b.y1 - b.y0) * 0.155;
+
+    let sumR2 = 0;
+    for (const bub of arr) {
+      bub.energy *= decayK;
+      bub.boost *= Math.exp(-dt / 0.45);
+      const f = clamp(bub.energy / this.energyMax, 0, 1);
+      const target = rMin + (rMax - rMin) * Math.sqrt(f);
+      (bub as FieldBubble & { target: number }).target = target;
+      sumR2 += target * target;
+    }
+    const fieldArea = (b.x1 - b.x0) * (b.y1 - b.y0);
+    const areaScale = Math.min(1, Math.sqrt((fieldArea * 0.3) / (Math.PI * sumR2 || 1)));
+    for (const bub of arr) {
+      const target = (bub as FieldBubble & { target: number }).target * areaScale;
+      bub.radius += (target - bub.radius) * (1 - Math.exp(-dt * 6));
+    }
+
+    const pad = 10;
+    for (let i = 0; i < arr.length; i++) {
+      const a = arr[i];
+      const nx = Math.sin(this.time * 0.35 + a.driftX) * 0.9 + Math.sin(this.time * 0.13 + a.driftY * 1.7) * 0.5;
+      const ny = Math.cos(this.time * 0.29 + a.driftY) * 0.9 + Math.sin(this.time * 0.17 + a.driftX * 1.3) * 0.5;
+      a.vx += nx * 3.2 * dt;
+      a.vy += ny * 3.2 * dt;
+      a.vx += (cx - a.x) * 0.13 * dt;
+      a.vy += (cy - a.y) * 0.13 * dt;
+      for (let j = i + 1; j < arr.length; j++) {
+        const c = arr[j];
+        let dx = c.x - a.x;
+        let dy = c.y - a.y;
+        const min = a.radius + c.radius + pad;
+        const d2 = dx * dx + dy * dy;
+        if (d2 < min * min) {
+          const d = Math.sqrt(d2) || 0.001;
+          const push = ((min - d) / min) * 52 * dt;
+          dx /= d;
+          dy /= d;
+          a.vx -= dx * push;
+          a.vy -= dy * push;
+          c.vx += dx * push;
+          c.vy += dy * push;
+        }
+      }
+    }
+
+    for (const bub of arr) {
+      bub.vx *= 0.93;
+      bub.vy *= 0.93;
+      const vmax = 60;
+      const sp = Math.hypot(bub.vx, bub.vy);
+      if (sp > vmax) {
+        bub.vx *= vmax / sp;
+        bub.vy *= vmax / sp;
+      }
+      bub.x += bub.vx * dt;
+      bub.y += bub.vy * dt;
+      const wall = 6;
+      if (bub.x - bub.radius < b.x0 + wall) bub.vx += (b.x0 + wall - (bub.x - bub.radius)) * 4 * dt;
+      if (bub.x + bub.radius > b.x1 - wall) bub.vx -= (bub.x + bub.radius - (b.x1 - wall)) * 4 * dt;
+      if (bub.y - bub.radius < b.y0 + wall) bub.vy += (b.y0 + wall - (bub.y - bub.radius)) * 4 * dt;
+      if (bub.y + bub.radius > b.y1 - wall) bub.vy -= (bub.y + bub.radius - (b.y1 - wall)) * 4 * dt;
+    }
+
+    // Two relaxation passes resolve overlaps the springs miss, so neighbouring
+    // bubbles keep a readable gap.
+    for (let pass = 0; pass < 2; pass++) {
+      for (let i = 0; i < arr.length; i++) {
+        const a = arr[i];
+        for (let j = i + 1; j < arr.length; j++) {
+          const c = arr[j];
+          let dx = c.x - a.x;
+          let dy = c.y - a.y;
+          const min = a.radius + c.radius + pad;
+          const d2 = dx * dx + dy * dy;
+          if (d2 >= min * min) continue;
+          const d = Math.sqrt(d2) || 0.001;
+          const corr = (min - d) * 0.55;
+          dx /= d;
+          dy /= d;
+          const wA = c.radius / (a.radius + c.radius + 0.001);
+          a.x -= dx * corr * wA;
+          a.y -= dy * corr * wA;
+          c.x += dx * corr * (1 - wA);
+          c.y += dy * corr * (1 - wA);
+        }
+      }
+    }
+    for (const bub of arr) {
+      bub.x = clamp(bub.x, b.x0 + bub.radius * 0.55, b.x1 - bub.radius * 0.55);
+      bub.y = clamp(bub.y, b.y0 + bub.radius * 0.55, b.y1 - bub.radius * 0.55);
+    }
+
+    for (const [k, bub] of this.bubbles) {
+      if (bub.energy < 0.012 && this.time - bub.born > 1.5) this.bubbles.delete(k);
+    }
+  }
+
+  seek(t: number) {
+    const target = clamp(t, 0, this.duration);
+    if (target < this.time) this.reset();
+    const steps = Math.ceil((target - this.time) / FIELD_DT);
+    for (let i = 0; i < steps; i++) this.tick();
+  }
+}

--- a/apps/webapp/components/jlens/jlens-field.tsx
+++ b/apps/webapp/components/jlens/jlens-field.tsx
@@ -1,0 +1,506 @@
+'use client';
+
+// The jlens "Field" view: an animated, time-based reading of a run's lens
+// read-outs, as an alternative to the token-by-token transcript. Concepts the
+// lens surfaces rise as bubbles (size = accumulated decode-probability mass,
+// colour = salience vs the strongest concept) and fade as the model moves on,
+// so you can watch what is in the model's workspace across the whole generation
+// rather than inspecting one token at a time. All the simulation lives in the
+// framework-free `jlens-field-sim` module; this component only owns the canvas,
+// the playback loop, and the controls.
+
+import { LensTokenMessage, LensType } from '@/lib/utils/lens';
+import { List, Orbit, Pause, Play, RotateCcw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  buildFieldSteps,
+  clamp,
+  DEFAULT_FIELD_CONFIG,
+  FIELD_DT,
+  FIELD_RAMP,
+  FieldBounds,
+  FieldSim,
+  hasAnyConcepts,
+  rampColor,
+  smoothstep,
+} from './jlens-field-sim';
+
+// Canvas label font, with CJK fallbacks so non-latin read-out tokens render.
+const FIELD_FONT =
+  '"Inter","SF Pro Text","Segoe UI",system-ui,"Noto Sans SC","PingFang SC","Microsoft YaHei",sans-serif';
+const SPEEDS = [0.5, 1, 2];
+const CANVAS_PADDING = 16;
+
+interface HoverInfo {
+  label: string;
+  salience: number;
+  peakLayer: number;
+  peakProb: number;
+  x: number;
+  y: number;
+}
+
+function formatTime(s: number): string {
+  const clamped = Math.max(0, s);
+  const mins = Math.floor(clamped / 60);
+  const secs = Math.floor(clamped % 60);
+  const tenths = Math.floor((clamped % 1) * 10);
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}.${tenths}`;
+}
+
+const rgba = (c: [number, number, number], a: number) => `rgba(${c[0]},${c[1]},${c[2]},${a})`;
+
+// Which reading the left panel shows: the default token transcript, or the
+// animated concept field.
+export type JlensLeftView = 'default' | 'field';
+
+// Segmented toggle between the transcript and the field, matching the sidebar's
+// LensModeToggle so it reads as part of the same control set. `defaultLabel`
+// names the transcript option per interface ("Tokens" for completion, "Chat"
+// for chat).
+export function JlensViewToggle({
+  view,
+  onChange,
+  defaultLabel,
+}: {
+  view: JlensLeftView;
+  onChange: (v: JlensLeftView) => void;
+  defaultLabel: string;
+}) {
+  const options: { value: JlensLeftView; label: string; icon: typeof List }[] = [
+    { value: 'default', label: defaultLabel, icon: List },
+    { value: 'field', label: 'Field', icon: Orbit },
+  ];
+  return (
+    <div className="flex flex-row items-center overflow-hidden rounded border border-sky-600">
+      {options.map((o, i) => {
+        const Icon = o.icon;
+        return (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onChange(o.value)}
+            aria-pressed={view === o.value}
+            className={`flex h-[23px] items-center justify-center gap-x-1 whitespace-nowrap px-2.5 py-1.5 text-[9.5px] font-semibold uppercase leading-none tracking-wide transition-colors ${
+              view === o.value ? 'bg-sky-600 text-white' : 'bg-white text-sky-600 hover:bg-sky-500 hover:text-white'
+            } ${i > 0 ? 'border-l border-sky-600' : ''}`}
+          >
+            <Icon className="h-3 w-3" />
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function JlensField({
+  tokens,
+  lensType,
+  layerStartFraction,
+  className,
+}: {
+  tokens: LensTokenMessage[];
+  lensType: LensType;
+  // Overrides the default layer window (fraction of low layers to drop).
+  layerStartFraction?: number;
+  className?: string;
+}) {
+  const config = useMemo(
+    () => ({
+      ...DEFAULT_FIELD_CONFIG,
+      lensType,
+      layerStartFraction: layerStartFraction ?? DEFAULT_FIELD_CONFIG.layerStartFraction,
+    }),
+    [lensType, layerStartFraction],
+  );
+
+  const steps = useMemo(() => buildFieldSteps(tokens, config), [tokens, config]);
+  const isEmpty = useMemo(() => !hasAnyConcepts(steps), [steps]);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const simRef = useRef<FieldSim | null>(null);
+  const rafRef = useRef<number>(0);
+  const lastTsRef = useRef<number>(0);
+  const playingRef = useRef<boolean>(false);
+  const speedRef = useRef<number>(1);
+  const boundsRef = useRef<FieldBounds>({ x0: 0, y0: 0, x1: 0, y1: 0 });
+  const dprRef = useRef<number>(1);
+
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState(1);
+  const [displayTime, setDisplayTime] = useState(0);
+  const [duration, setDuration] = useState(1);
+  const [hover, setHover] = useState<HoverInfo | null>(null);
+
+  speedRef.current = speed;
+
+  // ---- rendering ----
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const sim = simRef.current;
+    if (!canvas || !sim) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const b = boundsRef.current;
+    const w = b.x1 + CANVAS_PADDING;
+    const h = b.y1 + CANVAS_PADDING;
+
+    ctx.setTransform(dprRef.current, 0, 0, dprRef.current, 0, 0);
+    // Panel-matched light backdrop with a faint centre lift for depth.
+    ctx.fillStyle = '#f8fafc';
+    ctx.fillRect(0, 0, w, h);
+    const bg = ctx.createRadialGradient(w / 2, h * 0.46, 20, w / 2, h / 2, Math.max(w, h) * 0.7);
+    bg.addColorStop(0, 'rgba(255,255,255,0.9)');
+    bg.addColorStop(1, 'rgba(248,250,252,0)');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, w, h);
+
+    const bubbles = [...sim.bubbles.values()].sort((a, z) => a.energy - z.energy);
+    for (const bub of bubbles) {
+      const f = clamp(bub.energy / sim.energyMax, 0, 1);
+      const fade = smoothstep((sim.time - bub.born) / 0.5);
+      const alpha = fade * (0.4 + 0.6 * f);
+      if (alpha <= 0.01 || bub.radius < 1.5) continue;
+      const col = rampColor(f);
+
+      const grad = ctx.createRadialGradient(
+        bub.x,
+        bub.y - bub.radius * 0.3,
+        bub.radius * 0.1,
+        bub.x,
+        bub.y,
+        bub.radius,
+      );
+      grad.addColorStop(0, rgba(col, 0.28 * alpha + 0.06));
+      grad.addColorStop(0.7, rgba(col, 0.16 * alpha));
+      grad.addColorStop(1, rgba(col, 0.04 * alpha));
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(bub.x, bub.y, bub.radius, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.strokeStyle = rgba(col, (0.45 + 0.4 * f) * fade);
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+
+      if (bub.boost > 0.03) {
+        ctx.strokeStyle = rgba(col, bub.boost * 0.55);
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(bub.x, bub.y, bub.radius + 3 + 8 * (1 - bub.boost), 0, Math.PI * 2);
+        ctx.stroke();
+      }
+
+      if (bub.radius >= 13) {
+        let fontSize = clamp(bub.radius * 0.42, 10, 24);
+        ctx.font = `600 ${fontSize}px ${FIELD_FONT}`;
+        let textW = ctx.measureText(bub.label).width;
+        const maxIn = bub.radius * 1.85;
+        while (textW > maxIn && fontSize > 9) {
+          fontSize -= 1;
+          ctx.font = `600 ${fontSize}px ${FIELD_FONT}`;
+          textW = ctx.measureText(bub.label).width;
+        }
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        if (textW <= maxIn) {
+          // White halo keeps dark labels legible over the strongest fills.
+          ctx.lineWidth = 3;
+          ctx.strokeStyle = `rgba(255,255,255,${0.85 * fade})`;
+          ctx.strokeText(bub.label, bub.x, bub.y);
+          ctx.fillStyle = `rgba(15,23,42,${(0.7 + 0.3 * f) * fade})`;
+          ctx.fillText(bub.label, bub.x, bub.y);
+        }
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'alphabetic';
+      }
+    }
+  }, []);
+
+  // ---- sizing ----
+
+  const resize = useCallback(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+    const rect = container.getBoundingClientRect();
+    const cssW = Math.max(120, Math.floor(rect.width));
+    const cssH = Math.max(120, Math.floor(rect.height));
+    const dpr = Math.min(2, typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+    dprRef.current = dpr;
+    canvas.width = Math.floor(cssW * dpr);
+    canvas.height = Math.floor(cssH * dpr);
+    canvas.style.width = `${cssW}px`;
+    canvas.style.height = `${cssH}px`;
+    boundsRef.current = {
+      x0: CANVAS_PADDING,
+      y0: CANVAS_PADDING,
+      x1: cssW - CANVAS_PADDING,
+      y1: cssH - CANVAS_PADDING,
+    };
+    simRef.current?.setBounds(boundsRef.current);
+    draw();
+  }, [draw]);
+
+  // ---- playback loop ----
+
+  const stopLoop = useCallback(() => {
+    playingRef.current = false;
+    setPlaying(false);
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = 0;
+  }, []);
+
+  const startLoop = useCallback(() => {
+    const sim = simRef.current;
+    if (!sim || isEmpty) return;
+    if (sim.time >= sim.duration) sim.reset();
+    playingRef.current = true;
+    setPlaying(true);
+    lastTsRef.current = performance.now();
+    let acc = 0;
+    const loop = (ts: number) => {
+      if (!playingRef.current) return;
+      acc += Math.min(0.1, (ts - lastTsRef.current) / 1000) * speedRef.current;
+      lastTsRef.current = ts;
+      while (acc >= FIELD_DT) {
+        sim.tick();
+        acc -= FIELD_DT;
+      }
+      draw();
+      setDisplayTime(sim.time);
+      if (sim.time >= sim.duration) {
+        stopLoop();
+        return;
+      }
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+  }, [draw, isEmpty, stopLoop]);
+
+  const togglePlay = useCallback(() => {
+    if (playingRef.current) stopLoop();
+    else startLoop();
+  }, [startLoop, stopLoop]);
+
+  const seekToFraction = useCallback(
+    (frac: number) => {
+      const sim = simRef.current;
+      if (!sim) return;
+      sim.seek(clamp(frac, 0, 1) * sim.duration);
+      draw();
+      setDisplayTime(sim.time);
+    },
+    [draw],
+  );
+
+  const replay = useCallback(() => {
+    const sim = simRef.current;
+    if (!sim) return;
+    sim.reset();
+    setDisplayTime(0);
+    startLoop();
+  }, [startLoop]);
+
+  // Build (or rebuild) the sim whenever the run or config changes, then autoplay
+  // unless the visitor prefers reduced motion.
+  useEffect(() => {
+    stopLoop();
+    resize();
+    const sim = new FieldSim(steps, config, boundsRef.current);
+    simRef.current = sim;
+    setDuration(sim.duration);
+    setDisplayTime(0);
+    draw();
+    const reduced = typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (!isEmpty && !reduced) startLoop();
+    return () => stopLoop();
+    // startLoop/resize/draw are stable-by-callback; re-running only on data change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [steps, config, isEmpty]);
+
+  // Keep the canvas sized to its container.
+  useEffect(() => {
+    resize();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const ro = new ResizeObserver(() => resize());
+    if (containerRef.current) ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, [resize]);
+
+  // ---- scrubber (pointer-driven, styled like the layer slider) ----
+
+  const scrubRef = useRef<HTMLDivElement | null>(null);
+  const scrubbingRef = useRef(false);
+  const fractionFromClientX = (clientX: number, el: HTMLElement) => {
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 ? clamp((clientX - rect.left) / rect.width, 0, 1) : 0;
+  };
+
+  const progress = duration > 0 ? clamp(displayTime / duration, 0, 1) : 0;
+  const tokenIndex = simRef.current ? simRef.current.tokenIndexAt(displayTime) : 0;
+  const tokenCount = simRef.current?.stepCount ?? tokens.length;
+
+  // ---- hover read-out ----
+
+  const onCanvasMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const sim = simRef.current;
+    const canvas = canvasRef.current;
+    if (!sim || !canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    let best: HoverInfo | null = null;
+    let bestDist = Infinity;
+    for (const bub of sim.bubbles.values()) {
+      const d = Math.hypot(bub.x - mx, bub.y - my);
+      if (d < bub.radius + 4 && d < bestDist) {
+        bestDist = d;
+        best = {
+          label: bub.label,
+          salience: clamp(bub.energy / sim.energyMax, 0, 1),
+          peakLayer: bub.peakLayer,
+          peakProb: bub.peakProb,
+          x: mx,
+          y: my,
+        };
+      }
+    }
+    setHover(best);
+  };
+
+  if (isEmpty) {
+    return (
+      <div
+        className={`flex min-h-0 flex-1 flex-col items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 text-center text-slate-400 ${className ?? ''}`}
+      >
+        <div className="text-[13px] font-medium text-slate-500">No concepts to animate</div>
+        <div className="mt-1 max-w-xs text-[11px] leading-snug">
+          This run has no lens read-outs above the noise floor for the selected lens and layer window.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex min-h-0 flex-1 flex-col gap-y-2 ${className ?? ''}`}>
+      <div ref={containerRef} className="relative min-h-0 flex-1 overflow-hidden rounded-2xl border border-slate-200">
+        <canvas
+          ref={canvasRef}
+          className="block h-full w-full"
+          onMouseMove={onCanvasMove}
+          onMouseLeave={() => setHover(null)}
+        />
+        {hover && (
+          <div
+            className="pointer-events-none absolute z-10 max-w-[220px] rounded-md border border-slate-200 bg-white/95 px-2.5 py-1.5 text-[11px] shadow-md backdrop-blur-sm"
+            style={{
+              left: clamp(hover.x + 12, 8, (boundsRef.current.x1 || 200) - 160),
+              top: clamp(hover.y + 12, 8, (boundsRef.current.y1 || 200) - 40),
+            }}
+          >
+            <div className="font-semibold text-slate-800">{hover.label}</div>
+            <div className="mt-0.5 font-mono text-[10px] leading-relaxed text-slate-500">
+              salience {Math.round(hover.salience * 100)}%
+              {hover.peakLayer >= 0 && (
+                <>
+                  {' · '}
+                  peak {Math.round(hover.peakProb * 100)}% @ layer {hover.peakLayer}
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Transport bar, styled to the explorer's light controls. */}
+      <div className="flex flex-none flex-row items-center gap-x-2.5 px-1 pb-1">
+        <button
+          type="button"
+          onClick={togglePlay}
+          aria-label={playing ? 'Pause' : 'Play'}
+          className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-sky-700 text-white transition-colors hover:bg-sky-800"
+        >
+          {playing ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4 pl-0.5" />}
+        </button>
+        <button
+          type="button"
+          onClick={replay}
+          aria-label="Replay from start"
+          className="flex h-7 w-7 flex-none items-center justify-center rounded-md border border-slate-200 bg-white text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+        </button>
+
+        <div
+          ref={scrubRef}
+          className="relative h-[23px] flex-1 cursor-pointer touch-none select-none rounded border border-slate-300 bg-slate-200"
+          onPointerDown={(e) => {
+            scrubbingRef.current = true;
+            if (playingRef.current) stopLoop();
+            seekToFraction(fractionFromClientX(e.clientX, e.currentTarget));
+            e.currentTarget.setPointerCapture(e.pointerId);
+          }}
+          onPointerMove={(e) => {
+            if (!scrubbingRef.current) return;
+            seekToFraction(fractionFromClientX(e.clientX, e.currentTarget));
+          }}
+          onPointerUp={(e) => {
+            scrubbingRef.current = false;
+            if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
+          }}
+        >
+          <div
+            className="pointer-events-none absolute inset-y-0 left-0 rounded-[3px] bg-sky-600"
+            style={{ width: `${progress * 100}%` }}
+          />
+          <div
+            className="pointer-events-none absolute top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full border border-sky-700 bg-white shadow"
+            style={{ left: `${progress * 100}%` }}
+          />
+        </div>
+
+        <span className="flex-none whitespace-nowrap font-mono text-[10.5px] tabular-nums text-slate-500">
+          <span className="text-slate-700">{formatTime(displayTime)}</span> / {formatTime(duration)}
+          {' · '}
+          <span className="text-slate-700">{String(Math.max(1, tokenIndex)).padStart(2, '0')}</span>/{tokenCount}
+        </span>
+
+        <button
+          type="button"
+          onClick={() => {
+            const next = SPEEDS[(SPEEDS.indexOf(speed) + 1) % SPEEDS.length];
+            setSpeed(next);
+          }}
+          aria-label="Playback speed"
+          className="flex-none rounded-md border border-slate-200 bg-white px-2 py-1 font-mono text-[10.5px] font-semibold text-slate-500 transition-colors hover:bg-slate-100"
+        >
+          {speed}&times;
+        </button>
+      </div>
+
+      {/* Encoding legend, mirroring the sidebar's compact key. */}
+      <div className="flex flex-none flex-row items-center justify-center gap-x-4 pb-1 text-[9px] font-medium uppercase tracking-wide text-slate-400">
+        <span className="flex items-center gap-x-1.5">
+          <span className="inline-flex items-end gap-x-0.5">
+            <span className="inline-block h-1.5 w-1.5 rounded-full border border-slate-400" />
+            <span className="inline-block h-3 w-3 rounded-full border border-slate-400" />
+          </span>
+          size · probability mass
+        </span>
+        <span className="flex items-center gap-x-1.5">
+          <span
+            className="inline-block h-2 w-14 rounded-full"
+            style={{
+              background: `linear-gradient(to right, ${FIELD_RAMP.map(([f, c]) => `${rgba(c, 0.9)} ${Math.round(f * 100)}%`).join(', ')})`,
+            }}
+          />
+          salience · share of strongest
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #206.

### Problem

The Jacobian Lens explorer surfaces the concepts behind each token, per layer, as a readout you inspect one selection at a time. There is no way to see how those concepts move across a whole generation: which ones flare as the model works toward an answer, which fade, and when.

### Fix

Adds a "Field" view: an animated, time-based reading of the same run, toggled from the chat and completion panels. It reuses the run the explorer already has in memory, so it adds no API or inference work.

- `components/jlens/jlens-field-sim.ts`: a framework-free, deterministic simulation and parser over the existing `LensTokenMessage` stream. Deterministic so the scrubber can seek and replay reproducibly; framework-free so the logic is unit-testable on its own.
- `components/jlens/jlens-field.tsx`: the canvas view plus a Tokens/Field segmented toggle, built from the existing light UI (slate/sky palette, the same segmented-control and slider styling used elsewhere in the explorer). Bubble size tracks accumulated decode-probability mass; colour tracks salience relative to the strongest concept on screen. Includes play/pause, scrub, speed, replay, a hover read-out, and a legend.
- Wires the toggle into `jlens-chat.tsx` and `jlens-completion.tsx`. The field reads the already-loaded `tokens` and the active lens type (`LensModeContext` -> `lensTypesForMode`), so it stays in step with the Jacobian/Logit toggle. The change is additive: the existing transcript and readout are untouched, and the toggle is hidden while steering.
- Respects `prefers-reduced-motion` (no autoplay), scales to the panel via `ResizeObserver`, and shows an empty state when a run has no concepts above the noise floor.

### Testing

- New unit tests in `components/jlens/__tests__/jlens-field-sim.test.ts` (14 tests): token cleaning and junk filtering, per-layer concept aggregation (layer window, emitted-token hiding, probability floor, sort order), the colour ramp, and `FieldSim` behaviour (two sims seeked to the same time match exactly; seeking backward replays from the start; bubbles stay within bounds). `npx vitest run components/jlens/__tests__/jlens-field-sim.test.ts` passes (14/14).
- `tsc --noEmit` is clean, `eslint` is clean on the changed files, and `prettier` has been applied.
- Verified manually in the running webapp against a J-lens export, in both the completion and chat interfaces: toggle, play/pause, scrub, speed, replay, hover read-out, resize, and the empty state. Screenshot and animation are in #206.

### Notes and follow-ups

- The field uses its own default layer window (drops the lower half of layers, matching `START_LAYER_FRACTION`) rather than the sidebar's layer slider. Wiring it to the shared layer range would be a natural follow-up.
- In DIFF lens mode the field falls back to the Jacobian read-out, since DIFF has no single read-out direction of its own.
