### PR TITLE
Make inference CI runnable: drop the impossible 3.10 matrix leg, scope pytest to tests/

### DIFF
--- a/.github/workflows/inference-tests.yml
+++ b/.github/workflows/inference-tests.yml
@@ -15,8 +15,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install uv
@@ -34,4 +35,4 @@ jobs:
     - name: Type checking
       run: uv run pyright .
     - name: Run tests
-      run: uv run pytest
+      run: uv run pytest tests


### PR DESCRIPTION
### Problem

The "Inference - Tests" workflow cannot produce a meaningful result on any PR or push:

- Every run on `main` since 2026-07-10 fails at **Install dependencies** on the **3.10 matrix leg**: `apps/inference/pyproject.toml` declares `requires-python = ">=3.11,<3.14"`, so `uv sync --python 3.10` can never resolve. Matrix fail-fast then **cancels the 3.11/3.12 legs**, so the lint/format/typecheck/test steps never execute at all (example: run 29113662430).
- Even when the steps are reached, bare `uv run pytest` dies during **collection** on the vendored chatspace trees (`ModuleNotFoundError: No module named 'steerllm.tests'`, `ImportPathMismatchError` for `vendor/chatspace/tests` and `neuronpedia_inference/runpod_serverless/vendor/...`) before running a single first-party test.

### Fix

- Drop the `3.10` matrix entry (keep 3.11/3.12, matching `requires-python`).
- Add `fail-fast: false` so one leg's failure still reports the other.
- Scope the test step to `uv run pytest tests` — same selection as the repo's `make test` target — so vendored chatspace test files are not collected.

Deliberately *not* addressed here (pre-existing, larger scope): app-wide `ruff check .` (~2.9k findings, mostly under `vendor/`), `ruff format --check .` (~211 files), `pyright .` (~3.7k errors), and two `tests/unit/test_sae_manager.py` failures from sae-lens mock drift (red in the Codecov workflow since February). Excluding `vendor/` from ruff/pyright config would be a sensible follow-up.

### Testing

Rehearsed on a fork with this matrix/step shape (Alexander230/neuronpedia PR #1, runs 29406654972 / 29406654966): `uv sync` + all steps execute on 3.11 and 3.12, `pytest tests` collects and runs the first-party suite, and step outcomes exactly reproduce local results (2934 / 211 / 3723 pre-existing findings; unit tests 2 failed pre-existing, rest pass).

Related: unblocks meaningful CI results for #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
