### PR TITLE
Reduce Docker build memory usage to support 8GB default (fixes #198)

### DIFF
--- a/apps/webapp/next.config.js
+++ b/apps/webapp/next.config.js
@@ -129,42 +129,44 @@ module.exports = withMDX(nextConfig);
 
 const { withSentryConfig } = require('@sentry/nextjs');
 
-module.exports = withSentryConfig(module.exports, {
-  // For all available options, see:
-  // https://github.com/getsentry/sentry-webpack-plugin#options
+if (process.env.SENTRY_AUTH_TOKEN) {
+  module.exports = withSentryConfig(module.exports, {
+    // For all available options, see:
+    // https://github.com/getsentry/sentry-webpack-plugin#options
 
-  org: 'johnny-66',
-  project: 'neuronpedia',
+    org: 'johnny-66',
+    project: 'neuronpedia',
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+    // Only print logs for uploading source maps in CI
+    silent: !process.env.CI,
 
-  // For all available options, see:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+    // For all available options, see:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: true,
+    // Upload a larger set of source maps for prettier stack traces (increases build time)
+    widenClientFileUpload: true,
 
-  // Hides source maps from generated client bundles
-  hideSourceMaps: true,
-  telemetry: false,
+    // Hides source maps from generated client bundles
+    hideSourceMaps: true,
+    telemetry: false,
 
-  sourcemaps: {
-    deleteSourcemapsAfterUpload: true,
-  },
-
-  webpack: {
-    // Automatically annotate React components to show their full name in breadcrumbs and session replay
-    reactComponentAnnotation: {
-      enabled: true,
+    sourcemaps: {
+      deleteSourcemapsAfterUpload: true,
     },
 
-    // Automatically tree-shake Sentry logger statements to reduce bundle size
-    treeshake: {
-      removeDebugLogging: true,
-    },
+    webpack: {
+      // Automatically annotate React components to show their full name in breadcrumbs and session replay
+      reactComponentAnnotation: {
+        enabled: true,
+      },
 
-    // Enables automatic instrumentation of Vercel Cron Monitors.
-    automaticVercelMonitors: true,
-  },
-});
+      // Automatically tree-shake Sentry logger statements to reduce bundle size
+      treeshake: {
+        removeDebugLogging: true,
+      },
+
+      // Enables automatic instrumentation of Vercel Cron Monitors.
+      automaticVercelMonitors: true,
+    },
+  });
+}


### PR DESCRIPTION

### Problem

`make webapp-localhost-build` fails with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` on machines running Docker Desktop with its default memory setting of 8GB. This blocks contributors from building locally without first knowing to increase Docker's memory allocation. Closes #198

### Fix/Solution

- `apps/webapp/next.config.js`: Wrap `withSentryConfig` in an `if (process.env.SENTRY_AUTH_TOKEN)` check so the Sentry webpack plugin is only activated when credentials are present.

### Testing
**Environment:** MacOS Tahoe 26.0.1, Docker Desktop 4.60.1, Apple Silicon

Confirmed the OOM error reproduces with Docker Desktop set to 8GB

#### Manual testing of the fix 
  1. Set Docker Desktop memory to 8GB (Settings → Resources → Memory)
  1. Cleared the Docker build cache to ensure a clean build:
     ```bash
     docker builder prune -f
  1. Ran make webapp-localhost-build -> build succeeded
  1. Ran make webapp-localhost-run
  1. Verified the following pages at http://localhost:3000. Used Firefox Developer Console to verify no errors :
     - http://localhost:3000/admin  
     - http://localhost:3000/api-doc 
     - http://localhost:3000/sae-bench  
  1. Verified  http://localhost:3000/doesnotexist gives “Couldn‘t find that page.”


#### Automated testing of the fix 
- Reviewed Playwright tests in tests-playwright/production/. Not finding updates required since these tests run against the production Vercel deployment where SENTRY_AUTH_TOKEN is set and the Sentry plugin runs as before.

## Thought Process

The first approach considered was adding a memory gate to the Makefile that fails fast with a clear error when Docker memory is below a threshold. It doesn't solve the root problem though.

The more impactful fix is reducing how much memory the build actually needs. The Sentry webpack plugin (`withSentryConfig`) with `widenClientFileUpload: true` and `reactComponentAnnotation` enabled runs expensive extra webpack passes to generate and upload source maps. In a local Docker build, `SENTRY_AUTH_TOKEN` is not set, so the upload fails silently anyway. The plugin is doing expensive work for nothing.

Gating the plugin on `SENTRY_AUTH_TOKEN` skips this overhead in local builds, reducing peak memory enough for the build to complete at 8GB (the Docker Desktop default).

  ## Assumptions About Sentry
  - **Production Vercel builds** deploy directly on Vercel's platform and never use this Dockerfile. As long as `SENTRY_AUTH_TOKEN` is set in Vercel project settings, Sentry source map upload is unaffected.
  - **Production k8s builds** using this Dockerfile will also skip the plugin unless `SENTRY_AUTH_TOKEN` is passed in the build environment. Please confirm whether your k8s CI pipeline sets this token.
  - **Runtime error capture** (controlled by `SENTRY_DSN`) is completely unaffected — the runtime SDK already has `enabled: process.env.SENTRY_DSN !== undefined` in `sentry.server.config.ts` and `sentry.edge.config.ts`.
---

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
      <sub>The CLA grants Neuronpedia (Decode Research) the right to use, distribute, and sublicense your
      contribution, including under license terms that differ from the project's current
      license. You keep the copyright to your work. You only need to agree once — check the box
      on your first PR.</sub>
