### PR TITLE
Correct 'see' to 'sees' in tooltip text

### DIFF
--- a/apps/webapp/app/[modelId]/gemmascope/tab-microscope.tsx
+++ b/apps/webapp/app/[modelId]/gemmascope/tab-microscope.tsx
@@ -196,7 +196,7 @@ export default function TabMicroscope({
           </span>
           <div className="text-sm font-medium leading-normal text-slate-500">
             <span>
-              A <FeatureTooltip s={false} /> is something that activates in the {`AI's brain`} when it see a specific
+              A <FeatureTooltip s={false} /> is something that activates in the {`AI's brain`} when it sees a specific
               concept or idea, like
               {` "words about cats"`}.<br />
               For example, when you send an AI the message {`"I like cats"`}, it activates the {`"words about cats"`}{' '}


### PR DESCRIPTION
Fix grammatical error in tooltip explanation.

### Problem

just a small typo

### Fix/Solution

added an 's'

### Testing

visual check

---

<sub>By opening this pull request you contribute under the
[Apache License, Version 2.0](../LICENSE), per section 5 of that license. There is nothing
to sign, and you keep the copyright to your work. If your change includes code you did not
write, please name its source and license above.</sub>
