### PR TITLE
refactor: drop the transformerlens path from graph /steer

### DIFF
--- a/apps/graph/neuronpedia_graph/steer_generation.py
+++ b/apps/graph/neuronpedia_graph/steer_generation.py
@@ -1,34 +1,36 @@
 """Generation for `/steer`, against the interp_engine replacement model.
 
-`/steer` used to call `model.generate(...)` straight, which is a `HookedTransformer` method. On the
-default `interp_engine` engine the model is a plain `nn.Module` over a HuggingFace one, so the
-endpoint raised `AttributeError: 'InterpEngineReplacementModel' object has no attribute 'generate'`.
+`/steer` used to be written as if `HookedTransformer` were the only thing a graph pod can hold: it
+called `model.generate(...)` and asked that call for `stop_at_eos`, `freq_penalty` and
+`return_type="tokens"`, none of which exist anywhere else. `MODEL_ENGINE=interp_engine` is the
+default (see `runtime_env`) and is what every pod runs, and there the model is a plain `nn.Module`
+wrapping a HuggingFace one, so the endpoint died on the first of those: `AttributeError:
+'InterpEngineReplacementModel' object has no attribute 'generate'`.
 
-Everything here exists because the endpoint's *wire contract* is still TransformerLens-shaped even
-though nothing executes TransformerLens any more -- the steer modal's sliders are calibrated to it,
-and every shared steer result was produced under it -- while the generation underneath is now
-`transformers`' `generate`. Three things have to be translated, and each is silent rather than loud:
+Removing the attribute error is not enough to steer on that engine, which is why this is a module
+rather than one `getattr`. Three further things differ, and each is silent rather than loud:
 
-- `temperature=0` means argmax in `sample_logits` and the steer modal sends it by default, where
-  `transformers` rejects it. `freq_penalty` subtracts a flat amount per earlier occurrence of a
-  token, which is not `repetition_penalty` -- that scales the logit instead -- so it needs its own
-  processor. `stop_at_eos`, `verbose`, `return_type` and `use_past_kv_cache` have no counterpart at
-  all, and `feature_intervention_generate` forwards keywords it does not recognize into `generate`,
-  which refuses them ("The following `model_kwargs` are not used by the model").
-- `generate` starts from the checkpoint's own `generation_config.json`, and several families ship
-  sampling defaults there (Qwen3: temperature 0.6, top_p 0.95, top_k 20). TransformerLens applied
-  none of them, so the same steer request would otherwise sample from a truncated distribution.
-- `feature_intervention_generate` returns the continuation as *text*, and `/steer` needs the token
-  ids: it reports one row of top logits per token, so it has to know where the boundaries were.
-  Re-tokenizing the text to find them is exactly the bug commit bff40b1e ("correctly handle qwen
-  steering") removed, hence `_SequenceCollector`.
+- `feature_intervention_generate` forwards unrecognized keywords into `transformers`' `generate`,
+  which rejects them ("The following `model_kwargs` are not used by the model"). So the request's
+  knobs have to be *translated*, not passed along.
+- `transformers` starts from the checkpoint's own `generation_config.json`, and several families
+  ship sampling defaults there (Qwen3: temperature 0.6, top_p 0.95, top_k 20). The wire contract
+  applies none of those, so leaving them would sample from a truncated distribution for a request
+  that did not ask for one. `_NEUTRAL_SAMPLING` turns them off.
+- It returns the continuation as *text*. `/steer` needs the token ids: it reports one row of top
+  logits per token, so it has to know where the boundaries were. Re-tokenizing the text to find
+  them is exactly the bug commit bff40b1e ("correctly handle qwen steering") removed, hence
+  `_SequenceCollector`.
 
-The other two engines are refused rather than translated. `transformerlens` could generate here --
-it is the engine this endpoint was written for -- but no graph pod has run it since `interp_engine`
-became the default, and supporting it meant carrying two spellings of every sampling keyword for a
-path nothing exercised. `nnsight` reaches generation through a tracing context this endpoint never
-enters, so steering never worked there at all. Both remain fine for generating graphs; only this
-endpoint is narrower than the app.
+The request itself is still in TransformerLens' terms, because that is what the steer modal has
+always sent and its sliders are calibrated to: `temperature=0` means greedy rather than an error,
+and `freq_penalty` subtracts from a logit per earlier occurrence of that token rather than scaling
+it. Translating that is most of what this module does.
+
+The other two engines are turned away. `transformerlens` could be supported -- it is where these
+keywords come from -- but nothing deploys it, so a second path here would be a second untested
+path; a TL pod still generates graphs and fails only on steering. `nnsight` reaches generation
+through a tracing context this endpoint never enters, so steering never worked there at all.
 """
 
 from collections.abc import Sequence
@@ -44,7 +46,7 @@ from transformers.generation.streamers import BaseStreamer
 # for the ordering reason documented there. Every one of these is ignored unless `do_sample` is on,
 # which is why they are applied on that branch alone: `generate` warns about each flag it was given
 # and is not going to use, and a line of that per steer request is noise in a pod's logs.
-_HF_NEUTRAL_SAMPLING: dict[str, Any] = {
+_NEUTRAL_SAMPLING: dict[str, Any] = {
     "temperature": 1.0,
     "top_k": 0,
     "top_p": 1.0,
@@ -54,19 +56,18 @@ _HF_NEUTRAL_SAMPLING: dict[str, Any] = {
 
 
 class _TransformerLensSampling(LogitsProcessor):
-    """TransformerLens' temperature and frequency penalty, in the order `sample_logits` applies them.
-
-    Named for what it mirrors rather than for what runs it: this is the interp_engine path, and it
-    is here because those two knobs are `/steer`'s wire contract, not because TransformerLens is
-    involved.
+    """The request's temperature and frequency penalty, in the order `sample_logits` applies them.
 
     Both in one processor, and the temperature not left to `transformers`, because
     `_get_logits_processor` appends its `TemperatureLogitsWarper` *after* any caller-supplied
-    processor (there is a standing TODO in `generation/utils.py` about the ordering). TransformerLens
-    divides by the temperature and only then subtracts the penalty, so a separate processor would
-    subtract from logits that had not been scaled yet and answer the same request differently.
+    processor (there is a standing TODO in `generation/utils.py` about the ordering).
+    TransformerLens divides by the temperature and only then subtracts the penalty, so a separate
+    processor would subtract from logits that had not been scaled yet -- a difference the steer
+    modal's sliders would show as the penalty quietly changing strength with the temperature.
 
-    Non-positive penalties are ignored, as `sample_logits` ignores them.
+    `freq_penalty` is a flat subtraction per earlier occurrence of a token, which is not
+    `transformers`' `repetition_penalty` -- that one scales a logit instead, so it cannot stand in
+    for this. Non-positive penalties are ignored, as `sample_logits` ignores them.
     """
 
     def __init__(self, temperature: float, freq_penalty: float) -> None:
@@ -106,40 +107,46 @@ class _SequenceCollector(BaseStreamer):
 
 
 def _require_interp_engine(model: Any) -> None:
-    """Refuse a model this cannot generate with. Every circuit-tracer engine sets `backend`."""
+    """Refuse a model this endpoint cannot generate on, saying which one it got.
+
+    Every circuit-tracer replacement model sets `backend` on the instance, so its absence and its
+    value are two different misconfigurations and read as such.
+    """
     engine = getattr(model, "backend", None)
     if engine == "interp_engine":
         return
-    loaded = (
-        f"model engine {engine!r}"
-        if engine
-        else f"a {type(model).__name__}, which is not a circuit-tracer replacement model"
-    )
+    if engine is None:
+        raise NotImplementedError(
+            f"/steer needs a circuit-tracer replacement model and got a {type(model).__name__}, "
+            "which reports no `backend`. The lm-saes-crm attribution engine loads a model of its "
+            "own, and the rest of this handler needs the replacement model's intervention methods "
+            "as well as this one."
+        )
     raise NotImplementedError(
-        f"/steer generates through the interp_engine model engine; this pod loaded {loaded}. Every "
-        "deployed graph pod omits --model-engine and so gets interp_engine. Graph generation runs "
-        "on the other engines; steering does not."
+        f"/steer cannot generate with model engine {engine!r}; it supports 'interp_engine', which "
+        "is the default and what every graph pod runs. Graph generation is unaffected, so a pod "
+        "started with another engine serves everything but this endpoint."
     )
 
 
-def _hf_kwargs(max_new_tokens: int, temperature: float, freq_penalty: float) -> dict[str, Any]:
-    """The request in `transformers`' terms, sampling the way TransformerLens would."""
+def _generation_kwargs(max_new_tokens: int, temperature: float, freq_penalty: float) -> dict[str, Any]:
+    """The request in `transformers`' terms, sampling the way the wire contract means."""
     kwargs: dict[str, Any] = {
         "max_new_tokens": max_new_tokens,
         # Honored whether or not sampling is on, unlike the knobs below, and shipped in the
-        # `generation_config.json` of families this serves. TransformerLens' `generate` applies no
-        # repetition penalty, so neither does this.
+        # `generation_config.json` of families this serves. The request has no repetition penalty
+        # to ask for, so this is turned off rather than mirrored.
         "repetition_penalty": 1.0,
     }
     if temperature == 0:
         # `sample_logits` reads temperature 0 as argmax, and the graph steer modal sends 0 by
         # default (`STEER_TEMPERATURE_GRAPH`). `transformers` raises on it instead, so ask for
-        # greedy decoding, which is the same thing. TransformerLens drops the frequency penalty on
-        # this path too, so there is nothing to carry over.
+        # greedy decoding, which is the same thing. The frequency penalty is dropped on this path
+        # for the same reason `sample_logits` drops it: there is no distribution left to shape.
         kwargs["do_sample"] = False
         return kwargs
     kwargs["do_sample"] = True
-    kwargs.update(_HF_NEUTRAL_SAMPLING)
+    kwargs.update(_NEUTRAL_SAMPLING)
     kwargs["logits_processor"] = LogitsProcessorList([_TransformerLensSampling(temperature, freq_penalty)])
     return kwargs
 
@@ -151,13 +158,14 @@ def generate_default(
     temperature: float,
     freq_penalty: float,
 ) -> torch.Tensor:
-    """The unsteered continuation: the prompt's token ids followed by the generated ones."""
-    _require_interp_engine(model)
+    """The unsteered continuation: the prompt's token ids followed by the generated ones.
 
-    # Straight at the HuggingFace model: this is the baseline, so it wants none of the replacement
-    # model's intervention machinery. It is still the same forward pass -- the permanent hooks
-    # `InterpEngineReplacementModel` installs cache tensors and reroute gradients, leaving every
-    # value untouched -- so the two runs remain comparable.
+    Straight at the HuggingFace model, because this is the baseline and wants none of the
+    replacement model's intervention machinery. It is still the same forward pass -- the permanent
+    hooks `InterpEngineReplacementModel` installs cache tensors and reroute gradients, leaving
+    every value untouched -- so this run and the steered one remain comparable.
+    """
+    _require_interp_engine(model)
     tokens = model.ensure_tokenized(prompt)
     input_ids = tokens.unsqueeze(0)
     sequences = model.hf_model.generate(
@@ -165,7 +173,7 @@ def generate_default(
         attention_mask=torch.ones_like(input_ids),
         pad_token_id=model.tokenizer.pad_token_id or model.tokenizer.eos_token_id,
         use_cache=True,
-        **_hf_kwargs(max_new_tokens, temperature, freq_penalty),
+        **_generation_kwargs(max_new_tokens, temperature, freq_penalty),
     )
     return sequences[0]
 
@@ -181,21 +189,20 @@ def generate_steered(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """The steered continuation, and the logits that chose each generated token.
 
-    `freeze_attention` goes to the backend untouched. Worth knowing what it does there, since
-    neither this function nor the endpoint can make it more than it is: the freeze applies only to
-    the pass that consumes the prompt, so an intervention at the last position has nothing
-    downstream of it to hold constant, and it is skipped entirely when `interventions` is empty --
-    which is what the handler is left with when every steered position turns out to be unsteerable.
+    `freeze_attention` is handed to the backend rather than acted on here: it holds every layer's
+    attention pattern at the values a clean pass over the same prompt produced, for the pass that
+    consumes the prompt only. The backend installs those freezes only when there is at least one
+    intervention, which is what the handler can end up with after dropping features at unsteerable
+    positions.
     """
     _require_interp_engine(model)
-
     collector = _SequenceCollector()
     _, logits, _ = model.feature_intervention_generate(
         prompt,
         interventions,
         freeze_attention=freeze_attention,
         streamer=collector,
-        **_hf_kwargs(max_new_tokens, temperature, freq_penalty),
+        **_generation_kwargs(max_new_tokens, temperature, freq_penalty),
     )
     # `generate` hands the streamer its tokens on the CPU whatever the model's device; the caller
     # decodes them and runs a forward pass over them, so put them back where the model is.

--- a/apps/graph/tests/test_steer_generation.py
+++ b/apps/graph/tests/test_steer_generation.py
@@ -19,7 +19,7 @@ import torch
 from transformers import GPT2Config, GPT2LMHeadModel
 
 from neuronpedia_graph.steer_generation import (
-    _hf_kwargs,
+    _generation_kwargs,
     _SequenceCollector,
     _TransformerLensSampling,
     generate_default,
@@ -84,7 +84,7 @@ class FakeInterpEngineModel:
 
 def test_temperature_zero_asks_for_greedy_decoding():
     """The steer modal sends 0 by default, and `transformers` raises on it where TL means argmax."""
-    kwargs = _hf_kwargs(NEW_TOKENS, temperature=0.0, freq_penalty=0.0)
+    kwargs = _generation_kwargs(NEW_TOKENS, temperature=0.0, freq_penalty=0.0)
     assert kwargs["do_sample"] is False
     assert "logits_processor" not in kwargs
     # `generate` logs a line for every flag it was handed and will not use, and none of the sampling
@@ -94,7 +94,7 @@ def test_temperature_zero_asks_for_greedy_decoding():
 
 def test_sampling_ignores_the_checkpoints_own_generation_config():
     """Qwen3 ships temperature 0.6 / top_p 0.95 / top_k 20; TransformerLens applies none of them."""
-    kwargs = _hf_kwargs(NEW_TOKENS, temperature=0.7, freq_penalty=0.0)
+    kwargs = _generation_kwargs(NEW_TOKENS, temperature=0.7, freq_penalty=0.0)
     assert kwargs["do_sample"] is True
     assert kwargs["temperature"] == 1.0
     assert kwargs["top_k"] == 0


### PR DESCRIPTION
## Summary

Follow-up to 789942ed, which fixed `/steer` on the `interp_engine` model engine. That fix kept a
second code path for `transformerlens`, and no graph pod runs that engine — so it was a second
untested path carrying a second spelling of every generation keyword.

- `/steer` now generates on `interp_engine` alone. `generate_default` and `generate_steered` read
  straight through with no engine dispatch, and `_tl_kwargs` is gone.
- The other engines are refused by name. `_require_interp_engine` separates two misconfigurations
  that used to share one message: a model reporting a `backend` this endpoint cannot use, and a
  model with no `backend` at all, which is what the `lm-saes-crm` attribution engine loads. A pod
  on another engine still generates graphs and fails only here.
- Nothing about the wire contract changes. `temperature=0` still means greedy and `freq_penalty`
  still subtracts from a logit rather than scaling it, since that is what the steer modal sends, so
  `_TransformerLensSampling` and the translation into `transformers`' terms stay as they are.

`--model-engine transformerlens` remains available for graph generation, and the CRM parity harness
keeps its TransformerLens oracle — deleting that would remove the evidence behind defaulting to
`interp_engine`. `README.md` already documents `/steer` as the one narrower endpoint.

## Test plan

- [x] `apps/graph`: 11 unit tests in `tests/test_steer_generation.py`, covering the keyword
      translation, the frequency-penalty ordering, the token collector and each refused engine.
      They run on a randomly initialized two-layer GPT-2 built from a local config, so no
      download, no GPU, no tokenizer fetch.
- [x] `apps/graph`: full suite, 66 passed / 10 skipped (the skips are the opt-in CRM parity tests).
- [x] `pyright` at zero for the app; `make python-lint` clean.
- [x] Real gemma-2-2b with the gemma-scope transcoders on a GPU, across all four combinations of
      `freeze_attention` and sampling: correct token counts, one row of logits per generated token,
      and steering visibly moves the continuation. Freezing changes the output at temperature 0.8,
      confirming the frozen attention patterns reach the backend.

## Notes for review

The six-line change to the test file is renames only (`_hf_kwargs` -> `_generation_kwargs`), so
nothing it asserts moved — a reasonable signal that the deleted path was not carrying the substance.

Made with [Cursor](https://cursor.com)