### PR TITLE
fix: unbreak the cosine similarity pane and guard disabled inference

### DIFF
--- a/apps/webapp/app/api/activation/new/route.tsx
+++ b/apps/webapp/app/api/activation/new/route.tsx
@@ -1,3 +1,4 @@
+import { prisma } from '@/lib/db';
 import { assertUserCanAccessModelAndSourceSet } from '@/lib/db/userCanAccess';
 import { getActivationForFeature } from '@/lib/utils/inference';
 import { getSourceSetNameFromSource } from '@/lib/utils/source';
@@ -141,6 +142,31 @@ export const POST = withOptionalUser(async (request: RequestOptionalUser) => {
   } catch (error) {
     return NextResponse.json({ message: error instanceof Error ? error.message : 'Unknown Error' }, { status: 500 });
   }
+  // The dashboard hides the test box when inference is off, but this route takes unauthenticated
+  // calls, so the guard has to exist here too rather than only in the UI.
+  const target = await prisma.neuron.findUnique({
+    where: {
+      modelId_layer_index: { modelId: neuron.modelId, layer: neuron.layer, index: neuron.index.toString() },
+    },
+    select: {
+      hasVector: true,
+      model: { select: { inferenceEnabled: true } },
+      source: { select: { inferenceEnabled: true } },
+    },
+  });
+  if (!target) {
+    return NextResponse.json({ message: 'Feature not found.' }, { status: 404 });
+  }
+  // A vector is run by the model alone, so it only needs the model to be enabled. An SAE feature
+  // needs its source loaded on a host, which is what the source flag tracks.
+  const inferenceEnabled = target.hasVector ? target.model.inferenceEnabled : target.source?.inferenceEnabled;
+  if (!inferenceEnabled) {
+    return NextResponse.json(
+      { message: `Inference is not enabled for ${neuron.modelId}/${neuron.layer}.` },
+      { status: 400 },
+    );
+  }
+
   const activation = await getActivationForFeature(neuron, body.customText, request.user, body.ignoreBos === true);
 
   return NextResponse.json(activation);

--- a/apps/webapp/app/api/features/route.ts
+++ b/apps/webapp/app/api/features/route.ts
@@ -26,6 +26,11 @@ export const POST = withOptionalUser(async (request: RequestOptionalUser) => {
       return NextResponse.json({ message: 'Invalid JSON body' }, { status: 400 });
     }
 
+    // An empty list is a valid request with an empty answer, and the code below assumes at least one.
+    if (featuresRequest.length === 0) {
+      return NextResponse.json([]);
+    }
+
     const features: NeuronIdentifier[] = [];
     featuresRequest.forEach((feature) => {
       features.push(new NeuronIdentifier(feature.modelId, feature.layer, feature.index.toString()));
@@ -52,6 +57,7 @@ export const POST = withOptionalUser(async (request: RequestOptionalUser) => {
     if (error instanceof ValidationError) {
       return NextResponse.json({ message: error.message }, { status: 400 });
     }
+    console.error('[/api/features] failed:', error);
     return NextResponse.json({ message: 'Unknown Error' }, { status: 500 });
   }
 });

--- a/apps/webapp/lib/utils/inference.ts
+++ b/apps/webapp/lib/utils/inference.ts
@@ -239,24 +239,27 @@ export const getCosSimForFeature = async (
 
   const transformerLensModelId = await getTransformerLensModelIdIfExists(targetModelId);
 
-  return makeInferenceServerApiWithServerHost(serverHost).POST('/v1/util/sae-topk-by-decoder-cossim', {
-    body: {
-      ...(result?.hasVector
-        ? {
-            vector: result.vector,
-          }
-        : {
-            feature: {
-              model: feature.modelId,
-              source: feature.layer,
-              index: parseInt(feature.index, 10),
-            },
-          }),
-      model: transformerLensModelId,
-      source: targetSourceId,
-      numResults: 10,
-    },
-  });
+  // Callers read the payload's fields directly, so the openapi-fetch envelope comes off here.
+  return unwrapInferenceResponse(
+    makeInferenceServerApiWithServerHost(serverHost).POST('/v1/util/sae-topk-by-decoder-cossim', {
+      body: {
+        ...(result?.hasVector
+          ? {
+              vector: result.vector,
+            }
+          : {
+              feature: {
+                model: feature.modelId,
+                source: feature.layer,
+                index: parseInt(feature.index, 10),
+              },
+            }),
+        model: transformerLensModelId,
+        source: targetSourceId,
+        numResults: 10,
+      },
+    }),
+  );
 };
 
 type ActivationForFeatureResult = {


### PR DESCRIPTION
### Problem

Three defects, found while auditing a `NoComputeHostError` in production.

- **The "top features by cosine similarity" pane was always empty.** `getCosSimForFeature` was the only one of eight inference helpers that returned the raw `openapi-fetch` envelope instead of calling `unwrapInferenceResponse`, so `/api/cossim` answered `{"data": {...}}` while `cossim-pane.tsx` read `topkDecoderCossimFeatures` off the wrapper and got `undefined`. The GPU call itself was working the whole time.
- **That empty result then 500'd.** With no similar features, the pane asked `/api/features` for an empty list, and the route read `featuresRequest[0].maxActsToReturn` without checking for an empty array. The resulting `TypeError` was reported as `{"message": "Unknown Error"}` with nothing logged.
- **`/api/activation/new` never checked `inferenceEnabled`.** The feature dashboard hides the test box when inference is off, but the route accepts unauthenticated calls, so a direct request for a disabled source went straight to the host resolver and surfaced a missing host as a 500. This is what produced `NoComputeHostError: No INFERENCE host available for model "gemma-3-27b" source "40-gemmascope-2-res-65k"` — a model with `inferenceEnabled = false` at both the model and source level, which was never meant to have a host.

### Fix/Solution

- `getCosSimForFeature` now wraps its call in `unwrapInferenceResponse`, matching every other helper in the file. Callers read the payload's fields directly.
- `/api/features` returns `[]` for an empty request, and logs the real error before the generic 500.
- `/api/activation/new` checks `inferenceEnabled` before resolving a host, mirroring the dashboard: the model flag for vector features, the source flag for SAE features. It returns 400 with a clear message, or 404 when the feature does not exist.

One behavior change worth noting: a genuinely failing cossim call now throws instead of returning 200 with the error buried in the envelope, so real failures surface rather than silently producing an empty pane.

### Testing

- Confirmed against production before the fix: `POST /api/features` with `[]` returned 500, while a valid feature returned 200. `POST /api/cossim` returned 200 with real similarity scores wrapped in `data`, proving the inference host was healthy and the bug was client-side.
- The reporter confirmed the pane renders correctly with these changes.
- `tsc --noEmit` clean, 47 tests pass, Prettier and ESLint clean.

While auditing, I also checked inference coverage across the fleet: of 371 `inferenceEnabled` sources, only three cannot resolve to a host, and all three are `UNLISTED` (`gemma-2-9b-it/20-axbench-diffmean-res-16k` and two `gpt2-small` `neuronpedia-resid-pre` sources). No public source is affected. Separately, `qwen3-1.7b/llamascope-2-lorsa-16k-k64` is `graphEnabled` with no GRAPH host registered — not addressed here.

---

<sub>By opening this pull request you contribute under the
[Apache License, Version 2.0](../LICENSE), per section 5 of that license. There is nothing
to sign, and you keep the copyright to your work. If your change includes code you did not
write, please name its source and license above.</sub>

Made with [Cursor](https://cursor.com)