### PR TITLE
fix: make a static pod's tap set visible, and refuse a bad steer with a 400

### DIFF
--- a/apps/inference/neuronpedia_inference/config.py
+++ b/apps/inference/neuronpedia_inference/config.py
@@ -130,6 +130,10 @@ class Config:
     sae_gpu_budget_gib: str | None = None
     # Cap on page-locked host memory for those master copies. None = measure it.
     sae_pinned_host_gib: float | None = None
+    # Human-readable summary of what STATIC_POINTS (+ STATIC_POINTS_EXTRA) asked to declare, for
+    # the startup banner. A string rather than the addresses because this banner prints before the
+    # SAEs load, so `sae` has no address list yet; the resolved set is in the ready banner.
+    static_points_summary: str | None = None
 
     # Accepted as constructor arguments but stored under the derived names below.
     include_sae: InitVar[list[str] | None] = None
@@ -169,6 +173,7 @@ class Config:
         "exclude_sae_patterns",
         "backend",
         "num_gpus",
+        "static_points_summary",
     )
 
     def __post_init__(

--- a/apps/inference/neuronpedia_inference/endpoints/steer/completion.py
+++ b/apps/inference/neuronpedia_inference/endpoints/steer/completion.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from typing import Any, cast
 
 import torch
@@ -20,7 +20,13 @@ from interp_engine import generate_stream as engine_generate_stream
 from interp_engine import steer as engine_steer
 
 from neuronpedia_inference.config import Config
-from neuronpedia_inference.engine_adapter import BackendUnsupported, assert_steering_available, tlens_hook_to_point
+from neuronpedia_inference.engine_adapter import (
+    BackendUnsupported,
+    assert_steer_layers_declared,
+    assert_steering_available,
+    declares_static_taps,
+    tlens_hook_to_point,
+)
 from neuronpedia_inference.inference_utils.steering import (
     SteeringSettings,
     format_sse_message,
@@ -136,6 +142,14 @@ async def completion(request: SteerCompletionRequest):
             content={"error": "No features or vectors provided"},
             status_code=400,
         )
+
+    # Asked here because the spec that writes is built inside the generator, where a refusal is a
+    # 500 mid-stream rather than a status this can return.
+    if NPSteerType.STEERED in request.types and declares_static_taps(model):
+        try:
+            assert_steer_layers_declared(model, steer_write_layers(features))
+        except BackendUnsupported as exc:
+            return JSONResponse(content={"error": str(exc)}, status_code=400)
 
     max_new_tokens, no_room = resolve_max_new_tokens(len(tokens), int(request.n_completion_tokens))
     if no_room is not None:
@@ -261,6 +275,38 @@ def _feature_to_steerspec(
     )
 
 
+def steer_layer_for_hook(hook_name: str) -> int:
+    """Which layer a steer at ``hook_name`` writes: ``resid_pre[X]`` lands at ``X-1``.
+
+    Split out so the pre-flight write check and the spec that does the writing read the layer the
+    same way. Computing it twice is how a pod passes a check for one layer and fails the engine at
+    another.
+    """
+    if "resid_post" in hook_name:
+        return int(hook_name.split(".")[1])
+    if "resid_pre" in hook_name:
+        return int(hook_name.split(".")[1]) - 1
+    raise ValueError(f"Unsupported hook name for vLLM steering: {hook_name}")
+
+
+def steer_write_layers(features: Sequence[NPSteerFeature | NPSteerVector]) -> list[int]:
+    """The layers a steer over ``features`` will write to, sorted and deduplicated.
+
+    Answerable in the request handler, before a StreamingResponse has taken the reply away, where
+    :func:`features_to_vllm_steering_spec` runs inside the generator and cannot return a status.
+    Hooks it cannot map are left to that function, whose ValueError is already handled.
+    """
+    sae_manager = SAEManager.get_instance()
+    layers: set[int] = set()
+    for feature in features:
+        hook_name = sae_manager.get_sae_hook(feature.source) if isinstance(feature, NPSteerFeature) else feature.hook
+        try:
+            layers.add(steer_layer_for_hook(hook_name))
+        except ValueError:
+            continue
+    return sorted(layers)
+
+
 def features_to_vllm_steering_spec(settings: SteeringSettings) -> SteeringSpec:
     """Build an engine ``SteeringSpec`` (per-layer Add/ProjectionCap ops) for the vLLM backend.
 
@@ -271,12 +317,7 @@ def features_to_vllm_steering_spec(settings: SteeringSettings) -> SteeringSpec:
     layer_features: dict[int, list[tuple[NPSteerFeature | NPSteerVector, torch.Tensor]]] = {}
     for feature in settings.features:
         hook_name = sae_manager.get_sae_hook(feature.source) if isinstance(feature, NPSteerFeature) else feature.hook
-        if "resid_post" in hook_name:
-            layer = int(hook_name.split(".")[1])
-        elif "resid_pre" in hook_name:
-            layer = int(hook_name.split(".")[1]) - 1
-        else:
-            raise ValueError(f"Unsupported hook name for vLLM steering: {hook_name}")
+        layer = steer_layer_for_hook(hook_name)
 
         steering_vector = torch.tensor(feature.steering_vector, dtype=torch.float32)
         if not torch.isfinite(steering_vector).all():

--- a/apps/inference/neuronpedia_inference/endpoints/steer/completion_chat.py
+++ b/apps/inference/neuronpedia_inference/endpoints/steer/completion_chat.py
@@ -23,11 +23,14 @@ from neuronpedia_inference.endpoints.steer.completion import (
     _feature_to_steerspec,
     features_to_vllm_steering_spec,
     resolve_max_new_tokens,
+    steer_write_layers,
 )
 from neuronpedia_inference.engine_adapter import (
     BackendUnsupported,
     assert_capture_layers_declared,
+    assert_steer_layers_declared,
     assert_steering_available,
+    declares_static_taps,
     get_tokenize,
 )
 from neuronpedia_inference.inference_utils.persona import (
@@ -296,6 +299,16 @@ async def completion_chat(request: SteerCompletionChatRequest):
             content={"error": "No features or vectors provided"},
             status_code=400,
         )
+
+    # The write-side twin of the axis-layer check above, and asked for the same reason: the spec
+    # that writes is built inside the SSE generator, so a refusal there is a 500 mid-stream. A
+    # projection cap writes wherever the vector it caps was fitted, which on this endpoint is not
+    # the layer the axis reads -- the 70B pod declared 40 for the readout and was asked to write 32.
+    if wants_steering and declares_static_taps(model):
+        try:
+            assert_steer_layers_declared(model, steer_write_layers(features))
+        except BackendUnsupported as exc:
+            return JSONResponse(content={"error": str(exc)}, status_code=400)
 
     # Convert promptChatFormatted to NPSteerChatMessage for the readouts, so they analyze the
     # same conversation (including the system message, blanked or not) that generation saw.

--- a/apps/inference/neuronpedia_inference/engine_adapter.py
+++ b/apps/inference/neuronpedia_inference/engine_adapter.py
@@ -189,6 +189,73 @@ def assert_residual_available(model: object, what: str = "This endpoint", point:
     )
 
 
+def declares_static_taps(model: object) -> bool:
+    """True when this pod's tap set is fixed, so a per-layer check is worth asking at all.
+
+    Guards the work of resolving which layers a request would touch, not just the answer: on a
+    hooked pod that resolution reaches into the SAE manager for each feature's hook name, and a
+    check that cannot refuse anything should not be able to raise on the way to saying so.
+    """
+    return not getattr(model, "hooks_available", True)
+
+
+def _resid_aliases(address: Address) -> tuple[Address, ...]:
+    """The other name for the same residual add: ``resid_pre[L]`` IS ``resid_post[L-1]``.
+
+    Mirrors ``resid_stream_aliases`` in the engine's vllm_backend, which is what the refusals
+    these two checks pre-empt match against. Copied rather than imported: it is three lines, and
+    the import would reach past the package root into the vLLM backend module.
+
+    Drift is the risk that trades for, so these checks lean PERMISSIVE. A site this fails to
+    recognize as declared is one the engine refuses for itself, which is the 500 they exist to
+    replace and not a new failure; a site they wrongly call missing would refuse a request the pod
+    could have served.
+    """
+    if address.layer is None:
+        return (address,)
+    layer = int(address.layer)
+    if address.name == "resid_pre" and layer > 0:
+        return (address, Address("resid_post", layer - 1))
+    if address.name == "resid_post":
+        return (address, Address("resid_pre", layer + 1))
+    return (address,)
+
+
+def _undeclared_layers(declared: set[str], layers: list[int], point: str) -> list[int]:
+    """Which of ``layers`` no alias of ``point`` covers, sorted and deduplicated."""
+    return sorted(
+        {
+            layer
+            for layer in layers
+            if not any(str(alias) in declared for alias in _resid_aliases(Address(point, layer)))
+        }
+    )
+
+
+def _static_layer_miss(
+    model: object,
+    layers: list[int],
+    point: str,
+    *,
+    private_attr: str,
+    public_attr: str,
+) -> tuple[list[int], list[str]] | None:
+    """``(missing layers, declared)`` for a static pod, or None when the question does not apply.
+
+    None covers both "hooks run, so every site is reachable" and "nothing declared at all", the
+    second because that pod is refused wholesale by :func:`assert_hooks_available` /
+    :func:`assert_steering_available` and a layer list would be the wrong reason to give.
+    """
+    if getattr(model, "hooks_available", True):
+        return None
+    declared = getattr(model, private_attr, None) or getattr(model, public_attr, ()) or ()
+    declared_keys = {str(address) for address in declared}
+    if not declared_keys:
+        return None
+    missing = _undeclared_layers(declared_keys, layers, point)
+    return (missing, sorted(declared_keys)) if missing else None
+
+
 def assert_capture_layers_declared(
     model: object,
     layers: list[int],
@@ -200,29 +267,53 @@ def assert_capture_layers_declared(
     :func:`assert_residual_available` asks whether ``point`` is declared at all, which is the
     right question for an endpoint that reads every layer or none. A readout axis reads exactly
     one, so a pod can declare ``resid_post`` and still not have the layer in hand: the 70B pod
-    declares the site its layer-50 SAE reads and is asked for layer 40 by an axis fitted there.
+    declared the site its layer-50 SAE reads and was asked for layer 40 by an axis fitted there.
 
     That distinction only started to matter when axes became database rows. A shipped asset was
     on disk before the graphs were recorded, so the mismatch was a deploy-time fact; an axis that
     arrives with the request makes it a per-request one, and the engine's own refusal comes from
-    inside the generate call -- a 500 with a traceback, after the prompt was rendered. Asked here
-    instead, it is a 400 that names the axis and the layer, which is a pod that needs
-    ``STATIC_POINTS_EXTRA`` rather than a bug.
+    inside the generate call -- a 500 with a traceback, after the prompt was rendered.
     """
-    if getattr(model, "hooks_available", True):
+    miss = _static_layer_miss(model, layers, point, private_attr="_static_reads", public_attr="static_points")
+    if miss is None:
         return
-    declared = getattr(model, "_static_reads", None) or getattr(model, "static_points", ()) or ()
-    declared_keys = {str(address) for address in declared}
-    if not declared_keys:
-        return  # Not a static pod; the hooks/native checks own this case.
-    missing = sorted({layer for layer in layers if f"{point}.{layer}" not in declared_keys})
-    if not missing:
-        return
+    missing, declared = miss
     raise BackendUnsupported(
         f"{what} reads {point} at layer(s) {missing}, which this pod did not declare. Its CUDA "
         f"graphs are recorded against a fixed tap set, so no layer can be added while it runs. "
-        f"Declared: {sorted(declared_keys)}. Relaunch it with those layers in "
-        f"STATIC_POINTS_EXTRA (e.g. STATIC_POINTS_EXTRA='[\"{point}.{missing[0]}\"]')."
+        f"Declared: {declared}. Relaunch it with those layers declared: STATIC_POINTS=auto covers "
+        f"every layer, and STATIC_POINTS_EXTRA adds a closed set beside STATIC_POINTS=sae "
+        f"(e.g. STATIC_POINTS_EXTRA='[\"{point}.{missing[0]}\"]')."
+    )
+
+
+def assert_steer_layers_declared(
+    model: object,
+    layers: list[int],
+    what: str = "Steered generation",
+    point: str = "resid_post",
+) -> None:
+    """The write-side twin of :func:`assert_capture_layers_declared`.
+
+    :func:`assert_steering_available` asks whether this pod declared ANY write site, which catches
+    a generation-only pod and misses the case that actually bit: writes declared, at other layers.
+    A projection cap writes wherever the feature or vector it caps was fitted, and an uploaded
+    vector can name any layer at all, so the set is not one a pod can enumerate at startup --
+    which is why the pod this was written for now declares every layer instead.
+
+    Kept separate from the read check because the two sets genuinely differ: an SAE set declares
+    writes under the ``resid_pre[L]`` -> ``resid_post[L-1]`` mapping, so a pod can hold a read at
+    a layer and no write there.
+    """
+    miss = _static_layer_miss(model, layers, point, private_attr="_static_writes", public_attr="static_writes")
+    if miss is None:
+        return
+    missing, declared = miss
+    raise BackendUnsupported(
+        f"{what} writes {point} at layer(s) {missing}, which this pod did not declare. Its CUDA "
+        f"graphs are recorded against a fixed tap set, so no write tap can be added while it "
+        f"runs. Declared for writing: {declared}. Relaunch it with STATIC_POINTS=auto, which "
+        f"declares every layer to read and to write."
     )
 
 

--- a/apps/inference/neuronpedia_inference/server.py
+++ b/apps/inference/neuronpedia_inference/server.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 import traceback
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
@@ -466,11 +466,93 @@ def _format_duration(seconds: float) -> str:
     return f"{minutes}m {secs}s" if minutes else f"{secs}s"
 
 
+def _format_address_ranges(addresses: Iterable[Address]) -> str:
+    """Addresses as collapsed layer runs: ``resid_post.0-31,40 attn.0-3``.
+
+    An `auto` pod declares one address per layer, so the literal list on a 70B model is 80 entries
+    per direction and reads as noise. Collapsed, the same set is short enough to scan, and the
+    shape of it -- every layer, or just the two an SAE and an axis happen to want -- is the part
+    worth seeing. One token per point name, layers grouped inside it.
+    """
+    by_name: dict[str, set[int]] = {}
+    # A point can be addressed without a layer (`Address.layer` is optional, for the sites that
+    # are not per-block), and such an address prints as the bare name.
+    layerless: set[str] = set()
+    for address in addresses:
+        if address.layer is None:
+            layerless.add(address.name)
+            continue
+        by_name.setdefault(address.name, set()).add(address.layer)
+    tokens: list[str] = []
+    for name in sorted(set(by_name) | layerless):
+        if name in layerless:
+            tokens.append(name)
+        layers = sorted(by_name.get(name, ()))
+        if not layers:
+            continue
+        runs: list[str] = []
+        start = end = layers[0]
+        for layer in layers[1:]:
+            if layer == end + 1:
+                end = layer
+                continue
+            runs.append(f"{start}-{end}" if start != end else f"{start}")
+            start = end = layer
+        runs.append(f"{start}-{end}" if start != end else f"{start}")
+        tokens.append(f"{name}.{','.join(runs)}")
+    return " ".join(tokens) if tokens else "none"
+
+
+def _describe_requested_static_points(
+    static_mode: Any,
+    extra_points: list[Address],
+    *,
+    generation_only: bool,
+) -> str:
+    """What this pod asked to declare, for the config banner.
+
+    Printed before the SAEs load, so `sae` cannot be resolved to addresses yet and says so rather
+    than printing an empty set that would read as "nothing declared". The resolved truth is in the
+    ready banner at the end of startup, which is where the two differ.
+    """
+    if generation_only:
+        return "none (GENERATION_ONLY: completions only)"
+    extra = f" + {_format_address_ranges(extra_points)}" if extra_points else ""
+    if static_mode is None:
+        return "none (hooked backend: every point reachable)"
+    if static_mode in _SAE_RESOLVED_MODES:
+        return f"{static_mode} (resolved once the SAEs load){extra}"
+    if static_mode == "auto":
+        return f"auto (the block-output point at every layer, read and write){extra}"
+    # Whatever is left is the explicit JSON list, which is already addresses. Reached only after
+    # the named modes above: every one of them is a `str`, and a `str` is iterable, so falling
+    # through with one renders it a character at a time.
+    return f"{_format_address_ranges(to_address(point) for point in static_mode)}{extra}"
+
+
 def _log_banner(title: str, lines: list[str]) -> None:
     """One visually obvious block, so the end of a long noisy startup is findable."""
     bar = "=" * 100
     body = "\n".join(f"  {line}" for line in lines)
     logger.info("\n%s\n  %s\n%s\n%s\n%s\n", bar, title, "-" * 100, body, bar)
+
+
+def _declared_taps_line() -> str:
+    """The tap set as it actually resolved, read off the loaded model.
+
+    The config banner prints what was asked for, which for `sae` is a mode name and not a set.
+    This is the same question answered after the SAEs loaded and the extras were merged in, so a
+    pod whose axis layer is missing is visible at startup rather than on the first request that
+    needs it.
+    """
+    model = Model.get_instance()
+    reads = tuple(getattr(model, "static_points", ()) or ())
+    writes = tuple(getattr(model, "static_writes", ()) or ())
+    if not reads and not writes:
+        if getattr(model, "hooks_available", True):
+            return "none declared (hooked backend: every point reachable)"
+        return "none declared (graphs on, nothing capturable)"
+    return f"read {_format_address_ranges(reads)} | write {_format_address_ranges(writes)}"
 
 
 def _log_ready_banner(elapsed_seconds: float) -> None:
@@ -488,6 +570,7 @@ def _log_ready_banner(elapsed_seconds: float) -> None:
             f"({', '.join(sae_manager.valid_sae_sets) or 'none'})",
             f"token limits: prompt={config.token_limit} activation={config.activation_token_limit} "
             f"lens={config.lens_token_limit}",
+            f"static taps: {_declared_taps_line()}",
             f"startup took {_format_duration(elapsed_seconds)}",
         ],
     )
@@ -782,6 +865,7 @@ async def initialize(
         num_gpus = max(1, int(getattr(args, "num_gpus", 1) or 1))
         if num_gpus > 1:
             logger.info("Multi-GPU: sharding across %d GPUs (%s)", num_gpus, args.backend)
+        generation_only = _resolve_generation_only(args)
 
         config = Config(
             secret=SECRET,
@@ -802,7 +886,12 @@ async def initialize(
             num_gpus=num_gpus,
             sae_gpu_budget_gib=args.sae_gpu_budget_gib,
             sae_pinned_host_gib=args.sae_pinned_host_gib,
-            generation_only=_resolve_generation_only(args),
+            generation_only=generation_only,
+            static_points_summary=_describe_requested_static_points(
+                static_mode,
+                extra_points,
+                generation_only=generation_only,
+            ),
         )
         Config._instance = config
 
@@ -988,10 +1077,9 @@ async def initialize(
             )
             raise
 
-    # After the model is loaded: preload the vLLM engine (vLLM backend only), then
-    # initialize persona data for the assistant-axis feature. Persona data loads
-    # for whichever backend is active (vLLM or EagerModel); it's a no-op/warn
-    # when the model has no persona data files on disk.
+    # After the model is loaded, preload the vLLM engine (vLLM backend only). Nothing is loaded
+    # here for readout axes: they are database rows that travel with the request, so there is no
+    # per-model asset for startup to find.
     model = Model.get_instance()
     if isinstance(model, VLLMModel):
         # warmup() builds the engine, compiles decode kernels, and — when static taps

--- a/apps/inference/tests/unit/test_generation_only.py
+++ b/apps/inference/tests/unit/test_generation_only.py
@@ -139,6 +139,73 @@ class TestTheRequestLevelRefusal:
         assert_capture_layers_declared(SimpleNamespace(), [40])
         assert_capture_layers_declared(SimpleNamespace(hooks_available=True), [40])
 
+    def test_a_steer_at_an_undeclared_layer_is_refused_before_the_stream_opens(self):
+        """The write-side case: a projection cap writes where its vector was fitted, which is not
+        the layer the axis reads. The 70B pod declared 40 to read and was asked to write 32."""
+        from interp_engine.address import Address
+
+        from neuronpedia_inference.engine_adapter import assert_steer_layers_declared
+
+        pod = SimpleNamespace(
+            hooks_available=False,
+            graph_replay=True,
+            static_points=(Address("resid_post", 40), Address("resid_post", 50)),
+            static_writes=(Address("resid_post", 40), Address("resid_post", 50)),
+        )
+        with pytest.raises(BackendUnsupported) as excinfo:
+            assert_steer_layers_declared(pod, [32])
+        message = str(excinfo.value)
+        assert "[32]" in message
+        assert "STATIC_POINTS=auto" in message
+
+        assert_steer_layers_declared(pod, [40, 50])
+
+    def test_the_read_and_write_sets_are_asked_separately(self):
+        """An SAE set declares writes under the resid_pre[L] -> resid_post[L-1] mapping, so a pod
+        can hold a read at a layer and no write there. One check for both would miss it."""
+        from interp_engine.address import Address
+
+        from neuronpedia_inference.engine_adapter import (
+            assert_capture_layers_declared,
+            assert_steer_layers_declared,
+        )
+
+        pod = SimpleNamespace(
+            hooks_available=False,
+            graph_replay=True,
+            static_points=(Address("resid_post", 40),),
+            static_writes=(),
+        )
+        assert_capture_layers_declared(pod, [40])
+        # No writes declared at all is assert_steering_available's refusal, not a layer list.
+        assert_steer_layers_declared(pod, [40])
+
+    def test_a_hooked_pod_is_not_asked_which_layers_a_request_would_write(self):
+        """The gate exists so resolving those layers -- which reads each feature's hook out of the
+        SAE manager -- never runs on a pod where the answer could not refuse anything."""
+        from neuronpedia_inference.engine_adapter import declares_static_taps
+
+        assert declares_static_taps(SimpleNamespace(hooks_available=False)) is True
+        assert declares_static_taps(SimpleNamespace(hooks_available=True)) is False
+        assert declares_static_taps(SimpleNamespace()) is False
+
+    def test_a_layer_declared_under_the_other_residual_name_still_counts(self):
+        """`resid_pre[L]` IS `resid_post[L-1]`, and the engine matches on that. Checking the
+        literal name would refuse a request the pod can serve."""
+        from interp_engine.address import Address
+
+        from neuronpedia_inference.engine_adapter import assert_steer_layers_declared
+
+        pod = SimpleNamespace(
+            hooks_available=False,
+            graph_replay=True,
+            static_points=(),
+            static_writes=(Address("resid_pre", 33),),
+        )
+        assert_steer_layers_declared(pod, [32])
+        with pytest.raises(BackendUnsupported):
+            assert_steer_layers_declared(pod, [33])
+
     def test_an_unknown_backend_is_assumed_capable(self):
         # Anything without the attribute predates it and hooks in-process (eager, and the test
         # doubles for it). Defaulting to "refuse" here would break every such caller.

--- a/apps/inference/tests/unit/test_vllm_backend_kwargs.py
+++ b/apps/inference/tests/unit/test_vllm_backend_kwargs.py
@@ -23,7 +23,9 @@ from interp_engine import Address
 
 from neuronpedia_inference.server import (
     _DEFAULT_CUDAGRAPH_CAPTURE_SIZES,
+    _describe_requested_static_points,
     _engine_context_len,
+    _format_address_ranges,
     _parse_extra_static_points,
     _parse_static_points,
     _vllm_backend_kwargs,
@@ -172,6 +174,62 @@ def test_an_extra_point_is_declared_to_read_and_to_write():
     )
     assert [str(a) for a in reads] == ["resid_post.50", "resid_post.40"]
     assert [str(a) for a in writes] == ["resid_post.49", "resid_post.40"]
+
+
+def test_declared_taps_are_logged_as_ranges_rather_than_one_line_per_layer():
+    """80 addresses is what an `auto` 70B pod declares, and nobody reads 80 addresses."""
+    assert _format_address_ranges([]) == "none"
+    assert _format_address_ranges([Address("resid_post", 40)]) == "resid_post.40"
+    assert _format_address_ranges(Address("resid_post", n) for n in range(80)) == "resid_post.0-79"
+    # The gap is the point: a run and an isolated layer read differently at a glance.
+    assert (
+        _format_address_ranges([Address("resid_post", n) for n in range(4)] + [Address("resid_post", 40)])
+        == "resid_post.0-3,40"
+    )
+    # The 70B case, where the SAE site and the axis layer are both singletons.
+    assert _format_address_ranges([Address("resid_post", 50), Address("resid_post", 40)]) == "resid_post.40,50"
+
+
+def test_ranges_group_by_point_name_and_do_not_double_count_a_repeat():
+    assert (
+        _format_address_ranges(
+            [
+                Address("resid_post", 1),
+                Address("attn", 0),
+                Address("resid_post", 0),
+                Address("attn", 1),
+                Address("resid_post", 1),
+            ]
+        )
+        == "attn.0-1 resid_post.0-1"
+    )
+
+
+def test_a_point_with_no_layer_prints_as_the_bare_name():
+    """`Address.layer` is optional, for sites that are not per-block."""
+    assert _format_address_ranges([Address("embed", None)]) == "embed"
+    assert _format_address_ranges([Address("embed", None), Address("resid_post", 3)]) == "embed resid_post.3"
+
+
+def test_the_config_banner_says_a_resolved_mode_is_not_a_set_yet():
+    """It prints before the SAEs load. An empty list there would read as "nothing declared"."""
+    summary = _describe_requested_static_points("sae", [Address("resid_post", 40)], generation_only=False)
+    assert "sae" in summary
+    assert "resolved once the SAEs load" in summary
+    assert "resid_post.40" in summary
+
+    assert "GENERATION_ONLY" in _describe_requested_static_points(None, [], generation_only=True)
+    assert "every point reachable" in _describe_requested_static_points(None, [], generation_only=False)
+    # Every named mode is a `str`, and a `str` is iterable: falling through to the list branch
+    # with one renders it a character at a time ("a o t u"), which is how this read at first.
+    assert _describe_requested_static_points("auto", [], generation_only=False).startswith("auto (")
+    for mode in ("auto", "sae", "sae+auto"):
+        assert " ".join(mode) not in _describe_requested_static_points(mode, [], generation_only=False)
+    # An explicit list is already addresses, so it is shown as the set it is.
+    assert (
+        _describe_requested_static_points([["resid_post", 7], "resid_post.8"], [], generation_only=False)
+        == "resid_post.7-8"
+    )
 
 
 def test_an_extra_point_the_sae_set_already_covers_costs_nothing_twice():


### PR DESCRIPTION
Follow-up to #227. Two changes, both about the same thing: which sites a pod
declared decides whether a request is served, and that was neither visible at
startup nor reported cleanly when it went wrong.

## 1. The declared tap set is in both startup banners

Config banner, before the SAEs load:

```
Initialized Config with:
  model_id: meta-llama/Llama-3.3-70B-Instruct
  ...
  static_points_summary: sae (resolved once the SAEs load) + resid_post.40
```

Ready banner, read off the loaded model after resolution:

```
==== LOADING COMPLETE - SERVING ON http://localhost:5002 ====
  ...
  static taps: read resid_post.0-79 | write resid_post.0-79
  startup took 6m 12s
```

Two lines because they answer two questions. `sae` has no address list until the
SAEs load, so the first says that rather than printing an empty set that would
read as "nothing declared"; the second is the truth after the extras merge in. A
pod missing a layer its axes need is now visible at startup rather than on the
first request that needs it.

Ranges because the literal list is unreadable — `auto` on the 70B pod is 80
addresses per direction. One token per point name with layers grouped inside it,
so a gemmascope set reads `mlp_out_post.0-25 resid_mid.0-25`.

## 2. A steer at an undeclared layer is a 400, not a 500 mid-stream

#227 fixed the read side and left the write side asymmetric. An axis reading an
undeclared layer got a 400 naming the layer; a steer *writing* to one still died
inside `generate_steered`, well into a `StreamingResponse` that had already
returned 200:

```
ValueError: Steered generation asked for resid_post.32, which this engine did not
declare. ... Declared: resid_post.40, resid_post.50
```

`assert_steering_available` misses this because it asks whether the pod declared
*any* write site, which is the generation-only case. What bites is writes
declared, at other layers: a projection cap writes wherever the vector it caps
was fitted, so the pod declared 40 for the readout and was asked to write 32. An
uploaded vector can name any layer, so this is not a set a pod can enumerate.

Both checks now match sites the way the engine does, through the
`resid_pre[L]` == `resid_post[L-1]` alias, so a pod that declared one spelling is
not refused for the other — the read check in #227 compared literal names and was
stricter than the engine. They lean permissive on anything unrecognized, since
that degrades to the engine's own refusal (the failure they replace) where a
false refusal would break a request the pod could serve.

## Deploy note

The pod that prompted #227 no longer uses `STATIC_POINTS_EXTRA`: capping writes at
layers no list can enumerate, so it runs `STATIC_POINTS=auto` — priced at
util 0.90 with the prefill chunk pinned to 2048, which leaves KV at ~47,000
tokens. That lives in gitignored `local_scripts/pods.yaml`, so it is not in this
diff. `STATIC_POINTS_EXTRA` stays as the lever for a pod that cannot afford `auto`
and whose axis layers are a closed set; it now has no user.

## Test plan

- [x] `ruff check` + `ruff format --check`
- [x] Ranges: empty, single, full run, run plus outlier, grouping by point name,
      repeats, and a layerless address
- [x] Config summary for every `STATIC_POINTS` shape, including a regression test
      that a named mode is not iterated character by character
- [x] Write check: refusal names the layer and `STATIC_POINTS=auto`, read and
      write sets asked separately, alias match, and the hooked-pod gate
- [x] Full inference unit suite (555) + pyright, against a byte-identical tree in
      a fully-installed venv — this checkout's `apps/inference/.venv` is partial
      and cannot load `conftest.py`
- [ ] **Not exercised on a real static pod.** Both refusals and both banner lines
      are only proven by relaunching the 70B pod on this build

Made with [Cursor](https://cursor.com)