### PR TITLE
feat(graph): add deterministic supernode suggestion engine

### DIFF
--- a/apps/webapp/app/[modelId]/graph/supernode-suggestions.test.ts
+++ b/apps/webapp/app/[modelId]/graph/supernode-suggestions.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from 'vitest';
+import { CLTGraphLink, CLTGraphNode } from './graph-types';
+import { mergeAcceptedSupernodeSuggestions, suggestSupernodes, SupernodeSuggestion } from './supernode-suggestions';
+
+function makeNode(
+  id: string,
+  {
+    featureType = 'cross layer transcoder',
+    rawId = id,
+    jsNodeId = id,
+    layer = '1',
+    ctxIdx = 0,
+  }: {
+    featureType?: string;
+    rawId?: string;
+    jsNodeId?: string;
+    layer?: string;
+    ctxIdx?: number;
+  } = {},
+): CLTGraphNode {
+  return {
+    node_id: rawId,
+    nodeId: id,
+    feature: 0,
+    layer,
+    ctx_idx: ctxIdx,
+    feature_type: featureType,
+    token_prob: 0,
+    is_target_logit: false,
+    run_idx: 0,
+    reverse_ctx_idx: 0,
+    jsNodeId,
+    clerp: id,
+  };
+}
+
+function makeLink(source: CLTGraphNode, target: CLTGraphNode, weight: number, attachNodes = true): CLTGraphLink {
+  return {
+    source: source.node_id,
+    target: target.node_id,
+    weight,
+    ...(attachNodes ? { sourceNode: source, targetNode: target } : {}),
+  };
+}
+
+function graph(nodes: CLTGraphNode[], links: CLTGraphLink[]) {
+  return { nodes, links };
+}
+
+function incomingGraph(
+  candidateSpecs: Array<{ node: CLTGraphNode; weights: number[] }>,
+  upstreamNodes: CLTGraphNode[],
+) {
+  const candidates = candidateSpecs.map(({ node }) => node);
+  const links = candidateSpecs.flatMap(({ node, weights }) =>
+    weights.map((weight, index) => makeLink(upstreamNodes[index], node, weight)),
+  );
+  return graph([...upstreamNodes, ...candidates], links);
+}
+
+describe('suggestSupernodes', () => {
+  it('groups nodes with identical signed incoming profiles', () => {
+    const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
+    const left = makeNode('left');
+    const right = makeNode('right');
+    const result = suggestSupernodes(
+      incomingGraph(
+        [
+          { node: left, weights: [1, 0.5] },
+          { node: right, weights: [2, 1] },
+        ],
+        upstream,
+      ),
+      ['left', 'right'],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      label: 'Suggested group 1',
+      memberNodeIds: ['left', 'right'],
+      minCohesion: 1,
+      minSharedIncomingNeighbors: 2,
+    });
+  });
+
+  it('does not group profiles with opposite attribution signs', () => {
+    const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
+    const result = suggestSupernodes(
+      incomingGraph(
+        [
+          { node: makeNode('positive'), weights: [1, 1] },
+          { node: makeNode('negative'), weights: [-1, -1] },
+        ],
+        upstream,
+      ),
+      ['positive', 'negative'],
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('supports incoming, outgoing, and combined profile modes independently', () => {
+    const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
+    const downstream = [makeNode('down-1', { featureType: 'logit' }), makeNode('down-2', { featureType: 'logit' })];
+    const left = makeNode('left');
+    const right = makeNode('right');
+    const links = [
+      ...upstream.flatMap((node) => [makeLink(node, left, 1), makeLink(node, right, 1)]),
+      makeLink(left, downstream[0], 1),
+      makeLink(left, downstream[1], 1),
+      makeLink(right, downstream[0], -1),
+      makeLink(right, downstream[1], -1),
+    ];
+    const input = graph([...upstream, left, right, ...downstream], links);
+
+    expect(suggestSupernodes(input, ['left', 'right'], [], { profileMode: 'incoming' })).toHaveLength(1);
+    expect(suggestSupernodes(input, ['left', 'right'], [], { profileMode: 'outgoing' })).toEqual([]);
+    expect(suggestSupernodes(input, ['left', 'right'], [], { profileMode: 'both' })).toEqual([]);
+  });
+
+  it('requires the configured amount of shared-neighbor evidence', () => {
+    const upstream = [makeNode('shared', { featureType: 'embedding' })];
+    const input = incomingGraph(
+      [
+        { node: makeNode('left'), weights: [1] },
+        { node: makeNode('right'), weights: [1] },
+      ],
+      upstream,
+    );
+
+    expect(suggestSupernodes(input, ['left', 'right'])).toEqual([]);
+    expect(suggestSupernodes(input, ['left', 'right'], [], { minSharedNeighbors: 1 })).toHaveLength(1);
+  });
+
+  it('resolves raw edge IDs to displayed Anthropic node IDs without attached nodes', () => {
+    const upstream = [
+      makeNode('display-up-1', { featureType: 'embedding', rawId: 'raw-up-1', jsNodeId: 'display-up-1' }),
+      makeNode('display-up-2', { featureType: 'embedding', rawId: 'raw-up-2', jsNodeId: 'display-up-2' }),
+    ];
+    const left = makeNode('display-left', { rawId: 'raw-left', jsNodeId: 'display-left' });
+    const right = makeNode('display-right', { rawId: 'raw-right', jsNodeId: 'display-right' });
+    const links = upstream.flatMap((node) => [makeLink(node, left, 1, false), makeLink(node, right, 1, false)]);
+
+    expect(suggestSupernodes(graph([...upstream, left, right], links), ['display-left', 'display-right'])).toHaveLength(
+      1,
+    );
+  });
+
+  it('excludes unsupported, missing, zero-degree, and already grouped nodes', () => {
+    const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
+    const eligible = makeNode('eligible');
+    const unsupported = makeNode('unsupported', { featureType: 'logit' });
+    const grouped = makeNode('grouped');
+    const zeroDegree = makeNode('zero-degree');
+    const input = incomingGraph(
+      [
+        { node: eligible, weights: [1, 1] },
+        { node: unsupported, weights: [1, 1] },
+        { node: grouped, weights: [1, 1] },
+      ],
+      upstream,
+    );
+    input.nodes.push(zeroDegree);
+
+    expect(
+      suggestSupernodes(
+        input,
+        ['eligible', 'unsupported', 'grouped', 'zero-degree', 'missing'],
+        [['manual', 'grouped']],
+      ),
+    ).toEqual([]);
+  });
+
+  it('keeps feature types separate by default and can relax that constraint', () => {
+    const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
+    const input = incomingGraph(
+      [
+        { node: makeNode('mlp'), weights: [1, 1] },
+        { node: makeNode('attention', { featureType: 'lorsa' }), weights: [1, 1] },
+      ],
+      upstream,
+    );
+
+    expect(suggestSupernodes(input, ['mlp', 'attention'])).toEqual([]);
+    expect(suggestSupernodes(input, ['mlp', 'attention'], [], { sameFeatureTypeOnly: false })).toHaveLength(1);
+  });
+
+  it('uses complete-link validation to prevent chain clusters', () => {
+    const upstream = [makeNode('x', { featureType: 'embedding' }), makeNode('y', { featureType: 'embedding' })];
+    const input = incomingGraph(
+      [
+        { node: makeNode('a'), weights: [1, 0] },
+        { node: makeNode('b'), weights: [1, 1] },
+        { node: makeNode('c'), weights: [0, 1] },
+      ],
+      upstream,
+    );
+    const result = suggestSupernodes(input, ['a', 'b', 'c'], [], {
+      similarityThreshold: 0.7,
+      minSharedNeighbors: 1,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].memberNodeIds).toEqual(['a', 'b']);
+  });
+
+  it('enforces maximum group size without assigning a node twice', () => {
+    const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
+    const nodes = ['a', 'b', 'c', 'd'].map((id) => makeNode(id));
+    const input = incomingGraph(
+      nodes.map((node) => ({ node, weights: [1, 1] })),
+      upstream,
+    );
+    const result = suggestSupernodes(
+      input,
+      nodes.map((node) => node.nodeId || ''),
+      [],
+      { maxGroupSize: 2 },
+    );
+    const allMembers = result.flatMap((suggestion) => suggestion.memberNodeIds);
+
+    expect(result.every((suggestion) => suggestion.memberNodeIds.length === 2)).toBe(true);
+    expect(new Set(allMembers).size).toBe(allMembers.length);
+  });
+
+  it('is invariant to node, link, and pinned-ID ordering and does not mutate inputs', () => {
+    const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
+    const nodes = ['a', 'b', 'c'].map((id) => makeNode(id));
+    const input = incomingGraph(
+      nodes.map((node) => ({ node, weights: [1, 1] })),
+      upstream,
+    );
+    const originalInput = structuredClone(input);
+    const forward = suggestSupernodes(input, ['a', 'b', 'c']);
+    const reversed = suggestSupernodes(graph([...input.nodes].reverse(), [...input.links].reverse()), ['c', 'b', 'a']);
+
+    expect(reversed).toEqual(forward);
+    expect(input).toEqual(originalInput);
+  });
+});
+
+describe('mergeAcceptedSupernodeSuggestions', () => {
+  function suggestion(id: string, label: string, memberNodeIds: string[]): SupernodeSuggestion {
+    return {
+      id,
+      label,
+      memberNodeIds,
+      minCohesion: 1,
+      meanCohesion: 1,
+      minSharedIncomingNeighbors: 2,
+      minSharedOutgoingNeighbors: 0,
+      featureTypes: ['cross layer transcoder'],
+      layers: ['1'],
+      ctxIdxRange: [0, 0],
+    };
+  }
+
+  it('preserves manual groups and revalidates stale, overlapping, and unpinned members', () => {
+    const existing = [['manual', 'a']];
+    const suggestions = [
+      suggestion('first', 'Suggested group 1', ['a', 'b', 'c']),
+      suggestion('second', 'Suggested group 2', ['c', 'd']),
+      suggestion('third', 'Suggested group 3', ['e', 'f']),
+    ];
+    const result = mergeAcceptedSupernodeSuggestions({
+      existingSupernodes: existing,
+      suggestions,
+      acceptedSuggestionIds: new Set(['first', 'second', 'third']),
+      pinnedNodeIds: ['a', 'b', 'c', 'd', 'e'],
+    });
+
+    expect(result).toEqual([
+      ['manual', 'a'],
+      ['Suggested group 1', 'b', 'c'],
+    ]);
+    expect(existing).toEqual([['manual', 'a']]);
+    expect(suggestions[0].memberNodeIds).toEqual(['a', 'b', 'c']);
+  });
+
+  it('applies only explicitly accepted suggestions', () => {
+    const suggestions = [
+      suggestion('accepted', 'Accepted', ['a', 'b']),
+      suggestion('rejected', 'Rejected', ['c', 'd']),
+    ];
+    const result = mergeAcceptedSupernodeSuggestions({
+      existingSupernodes: [],
+      suggestions,
+      acceptedSuggestionIds: new Set(['accepted']),
+      pinnedNodeIds: ['a', 'b', 'c', 'd'],
+    });
+
+    expect(result).toEqual([['Accepted', 'a', 'b']]);
+  });
+});

--- a/apps/webapp/app/[modelId]/graph/supernode-suggestions.test.ts
+++ b/apps/webapp/app/[modelId]/graph/supernode-suggestions.test.ts
@@ -227,6 +227,12 @@ describe('suggestSupernodes', () => {
     );
 
     expect(suggestSupernodes(input, ['mlp', 'attention'])).toEqual([]);
+    expect(
+      suggestSupernodes(input, ['mlp', 'attention'], [], {
+        similarityThreshold: -1,
+        minSharedNeighbors: 0,
+      }),
+    ).toEqual([]);
     expect(suggestSupernodes(input, ['mlp', 'attention'], [], { sameFeatureTypeOnly: false })).toHaveLength(1);
   });
 

--- a/apps/webapp/app/[modelId]/graph/supernode-suggestions.test.ts
+++ b/apps/webapp/app/[modelId]/graph/supernode-suggestions.test.ts
@@ -146,6 +146,51 @@ describe('suggestSupernodes', () => {
     );
   });
 
+  it('recovers a human-authored Dallas subgroup from a reduced public graph fixture', () => {
+    // Reduced from the Response Dallas supernode in:
+    // https://transformer-circuits.pub/2025/attribution-graphs/graph_data/capital-state-dallas.json
+    const left = makeNode('2_16536263_-0', { rawId: '2_16536263_10', layer: '2', ctxIdx: 10 });
+    const right = makeNode('2_23133920_-0', { rawId: '2_23133920_10', layer: '2', ctxIdx: 10 });
+    const austinDecoy = makeNode('10_8513782_-0', { rawId: '10_8513782_11', layer: '10', ctxIdx: 11 });
+    const incoming = [
+      ['E_28948388_10', 2.2459492683410645, 1.5262408256530762],
+      ['1_21862382_10', 1.710408091545105, 1.098325490951538],
+      ['1_4418612_10', 0.6796928644180298, 0.5530434846878052],
+      ['1_13686348_10', 0.2643650770187378, 0.29762279987335205],
+    ] as const;
+    const outgoing = [
+      ['3_27636071_10', 1.0517706871032715, 0.6656948328018188],
+      ['3_22886075_10', 0.8075348138809204, 0.5080311894416809],
+      ['4_1348861_10', 0.5275150537490845, 0.29129698872566223],
+      ['15_21568836_11', 0.6396480202674866, 0.13760587573051453],
+    ] as const;
+    const contextNodes = [...incoming, ...outgoing].map(([id]) => makeNode(id, { featureType: 'embedding' }));
+    const decoyContext = [
+      makeNode('6_24231446_11', { featureType: 'embedding' }),
+      makeNode('15_2811388_11', { featureType: 'embedding' }),
+    ];
+    const contextById = new Map(contextNodes.map((node) => [node.node_id, node]));
+    const links = [
+      ...incoming.flatMap(([id, leftWeight, rightWeight]) => [
+        makeLink(contextById.get(id)!, left, leftWeight, false),
+        makeLink(contextById.get(id)!, right, rightWeight, false),
+      ]),
+      ...outgoing.flatMap(([id, leftWeight, rightWeight]) => [
+        makeLink(left, contextById.get(id)!, leftWeight, false),
+        makeLink(right, contextById.get(id)!, rightWeight, false),
+      ]),
+      makeLink(decoyContext[0], austinDecoy, 0.4334683120250702, false),
+      makeLink(austinDecoy, decoyContext[1], 1.7817903757095337, false),
+    ];
+    const input = graph([...contextNodes, ...decoyContext, left, right, austinDecoy], links);
+
+    const result = suggestSupernodes(input, [left.nodeId!, right.nodeId!, austinDecoy.nodeId!]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].memberNodeIds).toEqual([left.nodeId, right.nodeId]);
+    expect(result[0].minCohesion).toBeGreaterThan(0.9);
+  });
+
   it('excludes unsupported, missing, zero-degree, and already grouped nodes', () => {
     const upstream = [makeNode('up-1', { featureType: 'embedding' }), makeNode('up-2', { featureType: 'embedding' })];
     const eligible = makeNode('eligible');

--- a/apps/webapp/app/[modelId]/graph/supernode-suggestions.ts
+++ b/apps/webapp/app/[modelId]/graph/supernode-suggestions.ts
@@ -1,7 +1,7 @@
-import { CLTGraphLink, CLTGraphNode } from './graph-types';
+import type { CLTGraphLink, CLTGraphNode } from './graph-types';
 
 export const MAX_SUPERNODE_CANDIDATES = 200;
-export const GROUPABLE_FEATURE_TYPES = new Set(['cross layer transcoder', 'lorsa']);
+export const GROUPABLE_FEATURE_TYPES: ReadonlySet<string> = new Set(['cross layer transcoder', 'lorsa']);
 
 export type SupernodeProfileMode = 'both' | 'incoming' | 'outgoing';
 
@@ -53,6 +53,7 @@ type Candidate = {
 };
 
 type PairEvidence = {
+  eligible: boolean;
   score: number;
   sharedIncomingNeighbors: number;
   sharedOutgoingNeighbors: number;
@@ -249,6 +250,7 @@ function scorePair(left: Candidate, right: Candidate, config: SupernodeSuggestio
   }
 
   return {
+    eligible: selectedScores.length > 0,
     score: selectedScores.length > 0 ? average(selectedScores) : 0,
     sharedIncomingNeighbors,
     sharedOutgoingNeighbors,
@@ -340,7 +342,11 @@ function allCrossPairsPass(
 }
 
 function pairPasses(pair: PairEvidence, config: SupernodeSuggestionConfig): boolean {
-  return pair.score >= config.similarityThreshold && pair.selectedSharedNeighbors >= config.minSharedNeighbors;
+  return (
+    pair.eligible &&
+    pair.score >= config.similarityThreshold &&
+    pair.selectedSharedNeighbors >= config.minSharedNeighbors
+  );
 }
 
 function summarizeCluster(
@@ -384,7 +390,13 @@ function getEvidence(
 }
 
 function emptyEvidence(): PairEvidence {
-  return { score: 0, sharedIncomingNeighbors: 0, sharedOutgoingNeighbors: 0, selectedSharedNeighbors: 0 };
+  return {
+    eligible: false,
+    score: 0,
+    sharedIncomingNeighbors: 0,
+    sharedOutgoingNeighbors: 0,
+    selectedSharedNeighbors: 0,
+  };
 }
 
 function average(values: readonly number[]): number {

--- a/apps/webapp/app/[modelId]/graph/supernode-suggestions.ts
+++ b/apps/webapp/app/[modelId]/graph/supernode-suggestions.ts
@@ -1,0 +1,404 @@
+import { CLTGraphLink, CLTGraphNode } from './graph-types';
+
+export const MAX_SUPERNODE_CANDIDATES = 200;
+export const GROUPABLE_FEATURE_TYPES = new Set(['cross layer transcoder', 'lorsa']);
+
+export type SupernodeProfileMode = 'both' | 'incoming' | 'outgoing';
+
+export type SupernodeSuggestionConfig = {
+  profileMode: SupernodeProfileMode;
+  similarityThreshold: number;
+  minSharedNeighbors: number;
+  maxGroupSize: number;
+  sameFeatureTypeOnly: boolean;
+};
+
+export const DEFAULT_SUPERNODE_SUGGESTION_CONFIG: SupernodeSuggestionConfig = {
+  profileMode: 'both',
+  similarityThreshold: 0.75,
+  minSharedNeighbors: 2,
+  maxGroupSize: 8,
+  sameFeatureTypeOnly: true,
+};
+
+export type SupernodeSuggestion = {
+  id: string;
+  label: string;
+  memberNodeIds: string[];
+  minCohesion: number;
+  meanCohesion: number;
+  minSharedIncomingNeighbors: number;
+  minSharedOutgoingNeighbors: number;
+  featureTypes: string[];
+  layers: string[];
+  ctxIdxRange: [number, number];
+};
+
+type SuggestionGraph = {
+  nodes: readonly CLTGraphNode[];
+  links: readonly CLTGraphLink[];
+};
+
+type SparseProfile = Map<string, number>;
+
+type NodeProfiles = {
+  incoming: SparseProfile;
+  outgoing: SparseProfile;
+};
+
+type Candidate = {
+  id: string;
+  node: CLTGraphNode;
+  profiles: NodeProfiles;
+};
+
+type PairEvidence = {
+  score: number;
+  sharedIncomingNeighbors: number;
+  sharedOutgoingNeighbors: number;
+  selectedSharedNeighbors: number;
+};
+
+type ScoredPair = PairEvidence & {
+  leftId: string;
+  rightId: string;
+};
+
+export function suggestSupernodes(
+  graph: SuggestionGraph,
+  pinnedNodeIds: readonly string[],
+  existingSupernodes: readonly (readonly string[])[] = [],
+  configOverrides: Partial<SupernodeSuggestionConfig> = {},
+): SupernodeSuggestion[] {
+  const config = normalizeConfig(configOverrides);
+  const { displayedIdByAlias, nodeByDisplayedId } = buildNodeIdentityIndex(graph.nodes);
+  const existingMemberIds = new Set(existingSupernodes.flatMap((group) => group.slice(1)));
+  const candidateIds = [...new Set(pinnedNodeIds.slice(0, MAX_SUPERNODE_CANDIDATES))]
+    .filter((id) => {
+      const node = nodeByDisplayedId.get(id);
+      return node && GROUPABLE_FEATURE_TYPES.has(node.feature_type) && !existingMemberIds.has(id);
+    })
+    .sort(compareStrings);
+  const profilesByNodeId = buildProfiles(graph.links, candidateIds, displayedIdByAlias);
+  const candidates = candidateIds
+    .map((id) => {
+      const node = nodeByDisplayedId.get(id);
+      const profiles = profilesByNodeId.get(id);
+      return node && profiles && (profiles.incoming.size > 0 || profiles.outgoing.size > 0)
+        ? { id, node, profiles }
+        : null;
+    })
+    .filter((candidate): candidate is Candidate => candidate !== null);
+
+  if (candidates.length < 2) return [];
+
+  const evidence = buildPairEvidence(candidates, config);
+  const clusters = clusterCandidates(candidates, evidence, config);
+  const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+
+  const suggestions = clusters.map((memberNodeIds) => summarizeCluster(memberNodeIds, candidateById, evidence));
+  suggestions.sort(
+    (left, right) =>
+      right.minCohesion - left.minCohesion ||
+      compareStrings(left.memberNodeIds.join('|'), right.memberNodeIds.join('|')),
+  );
+
+  return suggestions.map((suggestion, index) => ({ ...suggestion, label: `Suggested group ${index + 1}` }));
+}
+
+export function mergeAcceptedSupernodeSuggestions({
+  existingSupernodes,
+  suggestions,
+  acceptedSuggestionIds,
+  pinnedNodeIds,
+}: {
+  existingSupernodes: readonly (readonly string[])[];
+  suggestions: readonly SupernodeSuggestion[];
+  acceptedSuggestionIds: ReadonlySet<string>;
+  pinnedNodeIds: readonly string[];
+}): string[][] {
+  const merged = existingSupernodes.map((group) => [...group]);
+  const usedNodeIds = new Set(existingSupernodes.flatMap((group) => group.slice(1)));
+  const pinnedSet = new Set(pinnedNodeIds.slice(0, MAX_SUPERNODE_CANDIDATES));
+
+  suggestions.forEach((suggestion) => {
+    if (!acceptedSuggestionIds.has(suggestion.id)) return;
+
+    const availableMembers = [...new Set(suggestion.memberNodeIds)].filter(
+      (nodeId) => pinnedSet.has(nodeId) && !usedNodeIds.has(nodeId),
+    );
+    if (availableMembers.length < 2) return;
+
+    merged.push([suggestion.label, ...availableMembers]);
+    availableMembers.forEach((nodeId) => usedNodeIds.add(nodeId));
+  });
+
+  return merged;
+}
+
+function normalizeConfig(overrides: Partial<SupernodeSuggestionConfig>): SupernodeSuggestionConfig {
+  const config = { ...DEFAULT_SUPERNODE_SUGGESTION_CONFIG, ...overrides };
+  return {
+    ...config,
+    similarityThreshold: clamp(finiteOr(config.similarityThreshold, 0.75), -1, 1),
+    minSharedNeighbors: Math.max(0, Math.floor(finiteOr(config.minSharedNeighbors, 2))),
+    maxGroupSize: clamp(Math.floor(finiteOr(config.maxGroupSize, 8)), 2, MAX_SUPERNODE_CANDIDATES),
+  };
+}
+
+function buildNodeIdentityIndex(nodes: readonly CLTGraphNode[]) {
+  const displayedIdByAlias = new Map<string, string>();
+  const nodeByDisplayedId = new Map<string, CLTGraphNode>();
+
+  nodes.forEach((node) => {
+    const displayedId = node.nodeId || node.node_id || node.jsNodeId;
+    if (!displayedId) return;
+    nodeByDisplayedId.set(displayedId, node);
+    [node.node_id, node.nodeId, node.jsNodeId].forEach((alias) => {
+      if (alias) displayedIdByAlias.set(alias, displayedId);
+    });
+  });
+
+  return { displayedIdByAlias, nodeByDisplayedId };
+}
+
+function buildProfiles(
+  links: readonly CLTGraphLink[],
+  candidateIds: readonly string[],
+  displayedIdByAlias: ReadonlyMap<string, string>,
+): Map<string, NodeProfiles> {
+  const profilesByNodeId = new Map(
+    candidateIds.map((id) => [id, { incoming: new Map<string, number>(), outgoing: new Map<string, number>() }]),
+  );
+
+  links.forEach((link) => {
+    if (!Number.isFinite(link.weight) || link.weight === 0) return;
+    const sourceId = resolveEndpointId(link.sourceNode, link.source, displayedIdByAlias);
+    const targetId = resolveEndpointId(link.targetNode, link.target, displayedIdByAlias);
+    if (!sourceId || !targetId || sourceId === targetId) return;
+
+    const sourceProfiles = profilesByNodeId.get(sourceId);
+    const targetProfiles = profilesByNodeId.get(targetId);
+    if (sourceProfiles) addProfileWeight(sourceProfiles.outgoing, targetId, link.weight);
+    if (targetProfiles) addProfileWeight(targetProfiles.incoming, sourceId, link.weight);
+  });
+
+  return profilesByNodeId;
+}
+
+function resolveEndpointId(
+  attachedNode: CLTGraphNode | undefined,
+  rawId: string,
+  displayedIdByAlias: ReadonlyMap<string, string>,
+): string | undefined {
+  const attachedId = attachedNode && (attachedNode.nodeId || attachedNode.node_id || attachedNode.jsNodeId);
+  if (attachedId) return displayedIdByAlias.get(attachedId) || attachedId;
+  return displayedIdByAlias.get(rawId);
+}
+
+function addProfileWeight(profile: SparseProfile, neighborId: string, weight: number) {
+  const nextWeight = (profile.get(neighborId) || 0) + weight;
+  if (nextWeight === 0) profile.delete(neighborId);
+  else profile.set(neighborId, nextWeight);
+}
+
+function buildPairEvidence(
+  candidates: readonly Candidate[],
+  config: SupernodeSuggestionConfig,
+): Map<string, Map<string, PairEvidence>> {
+  const evidence = new Map<string, Map<string, PairEvidence>>();
+  candidates.forEach((candidate) => evidence.set(candidate.id, new Map()));
+
+  for (let leftIndex = 0; leftIndex < candidates.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < candidates.length; rightIndex += 1) {
+      const left = candidates[leftIndex];
+      const right = candidates[rightIndex];
+      const pairEvidence = scorePair(left, right, config);
+      evidence.get(left.id)?.set(right.id, pairEvidence);
+      evidence.get(right.id)?.set(left.id, pairEvidence);
+    }
+  }
+  return evidence;
+}
+
+function scorePair(left: Candidate, right: Candidate, config: SupernodeSuggestionConfig): PairEvidence {
+  if (config.sameFeatureTypeOnly && left.node.feature_type !== right.node.feature_type) {
+    return emptyEvidence();
+  }
+
+  const incomingAvailable = left.profiles.incoming.size > 0 && right.profiles.incoming.size > 0;
+  const outgoingAvailable = left.profiles.outgoing.size > 0 && right.profiles.outgoing.size > 0;
+  const incomingScore = incomingAvailable
+    ? sparseCosineSimilarity(left.profiles.incoming, right.profiles.incoming)
+    : null;
+  const outgoingScore = outgoingAvailable
+    ? sparseCosineSimilarity(left.profiles.outgoing, right.profiles.outgoing)
+    : null;
+  const sharedIncomingNeighbors = countSharedNeighbors(left.profiles.incoming, right.profiles.incoming);
+  const sharedOutgoingNeighbors = countSharedNeighbors(left.profiles.outgoing, right.profiles.outgoing);
+  const selectedScores: number[] = [];
+  let selectedSharedNeighbors = 0;
+
+  if (config.profileMode !== 'outgoing' && incomingScore !== null) {
+    selectedScores.push(incomingScore);
+    selectedSharedNeighbors += sharedIncomingNeighbors;
+  }
+  if (config.profileMode !== 'incoming' && outgoingScore !== null) {
+    selectedScores.push(outgoingScore);
+    selectedSharedNeighbors += sharedOutgoingNeighbors;
+  }
+
+  return {
+    score: selectedScores.length > 0 ? average(selectedScores) : 0,
+    sharedIncomingNeighbors,
+    sharedOutgoingNeighbors,
+    selectedSharedNeighbors,
+  };
+}
+
+function sparseCosineSimilarity(left: SparseProfile, right: SparseProfile): number {
+  let leftNormSquared = 0;
+  let rightNormSquared = 0;
+  let dotProduct = 0;
+  left.forEach((value, key) => {
+    leftNormSquared += value * value;
+    dotProduct += value * (right.get(key) || 0);
+  });
+  right.forEach((value) => {
+    rightNormSquared += value * value;
+  });
+  if (leftNormSquared === 0 || rightNormSquared === 0) return 0;
+  return clamp(dotProduct / Math.sqrt(leftNormSquared * rightNormSquared), -1, 1);
+}
+
+function countSharedNeighbors(left: SparseProfile, right: SparseProfile): number {
+  const smaller = left.size <= right.size ? left : right;
+  const larger = smaller === left ? right : left;
+  let count = 0;
+  smaller.forEach((value, key) => {
+    if (value !== 0 && larger.has(key) && larger.get(key) !== 0) count += 1;
+  });
+  return count;
+}
+
+function clusterCandidates(
+  candidates: readonly Candidate[],
+  evidence: ReadonlyMap<string, ReadonlyMap<string, PairEvidence>>,
+  config: SupernodeSuggestionConfig,
+): string[][] {
+  const scoredPairs: ScoredPair[] = [];
+  for (let leftIndex = 0; leftIndex < candidates.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < candidates.length; rightIndex += 1) {
+      const leftId = candidates[leftIndex].id;
+      const rightId = candidates[rightIndex].id;
+      const pair = getEvidence(evidence, leftId, rightId);
+      if (pair && pairPasses(pair, config)) scoredPairs.push({ leftId, rightId, ...pair });
+    }
+  }
+  scoredPairs.sort(
+    (left, right) =>
+      right.score - left.score ||
+      compareStrings(left.leftId, right.leftId) ||
+      compareStrings(left.rightId, right.rightId),
+  );
+
+  const clusterById = new Map(candidates.map((candidate) => [candidate.id, [candidate.id]]));
+  const clusterIdByNodeId = new Map(candidates.map((candidate) => [candidate.id, candidate.id]));
+
+  scoredPairs.forEach((pair) => {
+    const leftClusterId = clusterIdByNodeId.get(pair.leftId);
+    const rightClusterId = clusterIdByNodeId.get(pair.rightId);
+    if (!leftClusterId || !rightClusterId || leftClusterId === rightClusterId) return;
+    const leftMembers = clusterById.get(leftClusterId);
+    const rightMembers = clusterById.get(rightClusterId);
+    if (!leftMembers || !rightMembers || leftMembers.length + rightMembers.length > config.maxGroupSize) return;
+    if (!allCrossPairsPass(leftMembers, rightMembers, evidence, config)) return;
+
+    const mergedMembers = [...leftMembers, ...rightMembers].sort(compareStrings);
+    const mergedClusterId = mergedMembers[0];
+    clusterById.delete(leftClusterId);
+    clusterById.delete(rightClusterId);
+    clusterById.set(mergedClusterId, mergedMembers);
+    mergedMembers.forEach((nodeId) => clusterIdByNodeId.set(nodeId, mergedClusterId));
+  });
+
+  return [...clusterById.values()].filter((members) => members.length >= 2);
+}
+
+function allCrossPairsPass(
+  leftMembers: readonly string[],
+  rightMembers: readonly string[],
+  evidence: ReadonlyMap<string, ReadonlyMap<string, PairEvidence>>,
+  config: SupernodeSuggestionConfig,
+): boolean {
+  return leftMembers.every((leftId) =>
+    rightMembers.every((rightId) => {
+      const pair = getEvidence(evidence, leftId, rightId);
+      return pair !== undefined && pairPasses(pair, config);
+    }),
+  );
+}
+
+function pairPasses(pair: PairEvidence, config: SupernodeSuggestionConfig): boolean {
+  return pair.score >= config.similarityThreshold && pair.selectedSharedNeighbors >= config.minSharedNeighbors;
+}
+
+function summarizeCluster(
+  memberNodeIds: string[],
+  candidateById: ReadonlyMap<string, Candidate>,
+  evidence: ReadonlyMap<string, ReadonlyMap<string, PairEvidence>>,
+): SupernodeSuggestion {
+  const pairEvidence: PairEvidence[] = [];
+  for (let leftIndex = 0; leftIndex < memberNodeIds.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < memberNodeIds.length; rightIndex += 1) {
+      const pair = getEvidence(evidence, memberNodeIds[leftIndex], memberNodeIds[rightIndex]);
+      if (pair) pairEvidence.push(pair);
+    }
+  }
+  const members = memberNodeIds
+    .map((id) => candidateById.get(id))
+    .filter((candidate): candidate is Candidate => !!candidate);
+  const ctxIndices = members.map((candidate) => candidate.node.ctx_idx);
+  const layers = [...new Set(members.map((candidate) => candidate.node.layer))].sort(compareStrings);
+
+  return {
+    id: `auto:${memberNodeIds.map(encodeURIComponent).join(',')}`,
+    label: '',
+    memberNodeIds: [...memberNodeIds],
+    minCohesion: Math.min(...pairEvidence.map((pair) => pair.score)),
+    meanCohesion: average(pairEvidence.map((pair) => pair.score)),
+    minSharedIncomingNeighbors: Math.min(...pairEvidence.map((pair) => pair.sharedIncomingNeighbors)),
+    minSharedOutgoingNeighbors: Math.min(...pairEvidence.map((pair) => pair.sharedOutgoingNeighbors)),
+    featureTypes: [...new Set(members.map((candidate) => candidate.node.feature_type))].sort(compareStrings),
+    layers,
+    ctxIdxRange: [Math.min(...ctxIndices), Math.max(...ctxIndices)],
+  };
+}
+
+function getEvidence(
+  evidence: ReadonlyMap<string, ReadonlyMap<string, PairEvidence>>,
+  leftId: string,
+  rightId: string,
+): PairEvidence | undefined {
+  return evidence.get(leftId)?.get(rightId);
+}
+
+function emptyEvidence(): PairEvidence {
+  return { score: 0, sharedIncomingNeighbors: 0, sharedOutgoingNeighbors: 0, selectedSharedNeighbors: 0 };
+}
+
+function average(values: readonly number[]): number {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- adds a pure TypeScript engine for suggesting structurally similar supernodes from pinned graph features;
- builds signed incoming and outgoing attribution-edge profiles and compares them with sparse cosine similarity;
- uses deterministic complete-link clustering with support, feature-type, overlap, and group-size guardrails;
- safely merges accepted suggestions into the existing manual-supernode representation;
- adds 13 focused tests, including a reduced fixture derived from Anthropic's public `capital-state-dallas` graph.

This is a **draft/RFC foundation PR**. It intentionally has no React/D3 call site so the clustering semantics and product scope can be reviewed before adding UI.

## Motivation

Manual supernodes already support grouping, renaming, persistence, sharing, and restoration. This PR produces the same `[label, ...memberNodeIds]` representation, so a follow-up UI can preview and selectively apply suggestions without API, database, schema, or graph-server changes.

## Algorithm

1. Consider at most the first 200 pinned, supported feature nodes.
2. Exclude nodes already in manual supernodes.
3. Build sparse signed incoming and outgoing profiles from the full loaded graph.
4. Score pairs with incoming, outgoing, or combined cosine similarity.
5. Require configured similarity and shared-neighbor support.
6. Merge candidates only when every cross-cluster pair passes, preventing chain clusters.
7. Revalidate pinned membership and overlap when accepted suggestions are merged into state.

Results are deterministic under node, link, and pinned-ID reordering. Inputs are not mutated.

## Validation

- `npm test -- --reporter=verbose`: 60/60 tests passed;
- `npm run lint`: passed with zero errors;
- `npm run format:check`: passed;
- IDE diagnostics: none;
- 200-candidate Chromium benchmark on a public Qwen CRM/LORSA graph with 87,565 edges:
  - 56.1 ms median;
  - 57.8 ms p95;
  - 62.6 ms maximum across 30 measured runs after warm-up.

Real-graph evaluation covered Anthropic CLT, legacy Neuronpedia Gemma CLT, and current Qwen CRM/LORSA artifacts. On the Anthropic graph with six human supernodes, the conservative default produced 84.2% pairwise precision and 8.6% recall against manual groups.

## Important Limitation

Edge-profile similarity measures **instance-level structural similarity**, not semantic equivalence. A Qwen explanation spot check found cohesion-above-0.97 pairs such as `say tech terms` with `lunar months`. This method may be useful for graph compression but must not be presented as semantic concept discovery.

If issue #145 requires semantic grouping, this design needs another signal—such as decoder similarity in a downstream encoder subspace—and the frontend-only split should change.

## Non-Goals

- no automatic grouping on graph load;
- no UI or production call site in this PR;
- no decoder/encoder weight loading;
- no LLM-generated labels;
- no backend, API, database, persistence-format, or dependency changes.

## Proposed Follow-Up

If structural grouping is accepted, PR2 will add a human-in-the-loop preview/apply interface beside the existing manual grouping controls. Existing groups will be preserved, and suggestions will never be auto-applied.

Refs #145.
