### PR TITLE
feat: record the HuggingFace repo id on Model, and stop hand-keeping the mapping

### DIFF
--- a/apps/graph/dump_openapi.py
+++ b/apps/graph/dump_openapi.py
@@ -22,8 +22,9 @@ from pathlib import Path
 # before the import below, which is what reads them.
 os.environ.setdefault("SECRET", "openapi-dump-placeholder")
 os.environ.setdefault("HF_TOKEN", "openapi-dump-placeholder")
-# Any name from HF_MODEL_ID_TO_NP_MODEL_ID will do -- which model is loaded does not appear
-# anywhere in the spec, and nothing is loaded here regardless.
+# Any key of hf_model_id_to_np_model_id() will do -- which model is loaded does not appear
+# anywhere in the spec, and nothing is loaded here regardless. The lifespan that would validate
+# this never runs, since importing the app does not start the server.
 os.environ.setdefault("MODEL_ID", "google/gemma-2-2b")
 
 from neuronpedia_graph.server import app  # noqa: E402

--- a/apps/graph/neuronpedia_graph/model_ids.py
+++ b/apps/graph/neuronpedia_graph/model_ids.py
@@ -1,0 +1,61 @@
+"""Translation between HuggingFace repo ids and Neuronpedia model ids.
+
+Its own module rather than part of ``server.py`` so that importing it costs nothing: the server
+refuses to import without a SECRET and an attribution backend, and a table of strings should not
+need either. That is also what lets the test guarding it run everywhere, rather than skipping on a
+machine that has no attribution extra installed.
+"""
+
+import json
+from functools import cache
+from pathlib import Path
+
+
+def _load_np_model_to_hf() -> dict[str, str]:
+    """Neuronpedia short id -> Hugging Face repo id, read from the repo root.
+
+    A second copy of the loader in ``apps/inference/neuronpedia_inference/config.py``. The apps are
+    separate projects with no shared package, so the duplicated function is deliberate; what
+    matters is that both read the one file rather than each keeping its own table.
+    """
+    # apps/graph/neuronpedia_graph/model_ids.py -> the repo root is three parents up.
+    path = Path(__file__).resolve().parents[3] / "np_model_to_hf.json"
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to read {path}: {exc}")
+        return {}
+
+
+# Used only where np_model_to_hf.json is not on disk, i.e. an image holding apps/graph without the
+# repo root. Every entry here must also be in that file: this is a copy for availability, not a
+# place to add a model, and a test asserts they agree.
+FALLBACK_HF_MODEL_ID_TO_NP_MODEL_ID = {
+    "google/gemma-2-2b": "gemma-2-2b",
+    "google/gemma-3-4b-it": "gemma-3-4b-it",
+    "Qwen/Qwen3-1.7B": "qwen3-1.7b",
+    "Qwen/Qwen3-4B": "qwen3-4b",
+}
+
+
+@cache
+def hf_model_id_to_np_model_id() -> dict[str, str]:
+    """Hugging Face repo id -> the Neuronpedia model id a graph is labelled with.
+
+    Reversed from np_model_to_hf.json rather than written out here. The hand-kept dict this
+    replaces carried ``"meta-llama/Llama-3.2-1B": "llama3.1-8b"`` -- a different model, whose id
+    went into the `scan` field of every graph such a pod produced, and which nothing compared
+    against the mapping file or the webapp's own copy.
+
+    Not interchangeable with NP_MODEL_ID. That labels graphs on the lm-saes-crm path only, and
+    always holds a value because start.py defaults it, so preferring it here would relabel every
+    circuit-tracer graph as whatever that default happened to be.
+    """
+    mapping = _load_np_model_to_hf()
+    if not mapping:
+        return dict(FALLBACK_HF_MODEL_ID_TO_NP_MODEL_ID)
+    return {hf_id: np_id for np_id, hf_id in mapping.items()}

--- a/apps/graph/neuronpedia_graph/server.py
+++ b/apps/graph/neuronpedia_graph/server.py
@@ -30,6 +30,7 @@ from neuronpedia_graph.chat_prompt import (
     strip_leading_bos,
     unsteerable_token_positions,
 )
+from neuronpedia_graph.model_ids import hf_model_id_to_np_model_id
 from neuronpedia_graph.runtime_env import get_device, get_model_dtype, get_model_engine
 from neuronpedia_graph.schemas import (
     CheckBusyResponse,
@@ -256,15 +257,10 @@ TRANSCODER_SET_TO_SOURCE_URL_ARRAYS = {
     ],
 }
 
-# HuggingFace model ID to the Neuronpedia model ID a graph is labelled with. Not TransformerLens'
-# list, despite the name it used to carry -- every engine loads these. `build_model` raises a
-# KeyError on an unlisted one, which is why the startup error below quotes the list.
-HF_MODEL_ID_TO_NP_MODEL_ID = {
-    "google/gemma-2-2b": "gemma-2-2b",
-    "google/gemma-3-4b-it": "gemma-3-4b-it",
-    "meta-llama/Llama-3.2-1B": "llama3.1-8b",
-    "Qwen/Qwen3-4B": "qwen3-4b",
-}
+
+# HuggingFace repo id -> the Neuronpedia model id a graph is labelled with. See model_ids.py; it
+# is reversed from np_model_to_hf.json rather than hand-kept here, which is what the dict this
+# replaced got wrong.
 
 
 def _circuit_tracer_version() -> str:
@@ -397,9 +393,19 @@ async def lifespan(_app: FastAPI):
     if not model_id_env:
         raise ValueError(
             "MODEL_ID is required. Pass --model_id, or set MODEL_ID. Models a graph can be labelled "
-            "with: " + ", ".join(HF_MODEL_ID_TO_NP_MODEL_ID.keys())
+            "with: " + ", ".join(sorted(hf_model_id_to_np_model_id()))
         )
     loaded_model_arg = model_id_env
+
+    # Refuse here rather than at build_model. The circuit-tracer path labels a graph with this, and
+    # an unlisted model used to raise a KeyError only once attribution had finished -- minutes of
+    # GPU work spent on a pod that was never going to be able to return a graph. The lm-saes-crm
+    # path is exempt because it labels from NP_MODEL_ID and never reads this map.
+    if ATTRIBUTION_ENGINE != "lm-saes-crm" and loaded_model_arg not in hf_model_id_to_np_model_id():
+        raise ValueError(
+            f"No Neuronpedia model id for MODEL_ID '{loaded_model_arg}'. Add it to "
+            "np_model_to_hf.json at the repo root. Known: " + ", ".join(sorted(hf_model_id_to_np_model_id()))
+        )
 
     device = get_device()
     model_dtype = get_model_dtype()
@@ -956,7 +962,7 @@ async def generate_graph(req_data: GraphGenerationRequest):
                 _used_nodes,
                 _used_edges,
                 slug_identifier,
-                HF_MODEL_ID_TO_NP_MODEL_ID[requested_model_id],
+                hf_model_id_to_np_model_id()[requested_model_id],
                 node_threshold,
                 tokenizer,
             )

--- a/apps/graph/neuronpedia_graph/steer_generation.py
+++ b/apps/graph/neuronpedia_graph/steer_generation.py
@@ -34,7 +34,7 @@ through a tracing context this endpoint never enters, so steering never worked t
 """
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast
 
 import torch
 from transformers import LogitsProcessor, LogitsProcessorList
@@ -74,12 +74,17 @@ class _TransformerLensSampling(LogitsProcessor):
         self.temperature = temperature
         self.freq_penalty = freq_penalty
 
-    def __call__(self, input_ids: torch.Tensor, scores: torch.Tensor) -> torch.Tensor:
-        scores = scores / self.temperature
+    # Returns `FloatTensor` because `LogitsProcessor.__call__` declares it and an override cannot
+    # widen a return type. The casts are what that costs: `FloatTensor` is a legacy per-dtype alias
+    # and no torch operation is annotated as producing one, so every expression below types as
+    # plain `Tensor`. Parameters stay `Tensor`, which is allowed -- accepting more than the base
+    # promises is safe, and `input_ids` is integral rather than float anyway.
+    def __call__(self, input_ids: torch.Tensor, scores: torch.Tensor) -> torch.FloatTensor:
+        scaled = scores / self.temperature
         if self.freq_penalty <= 0:
-            return scores
-        counts = torch.stack([torch.bincount(row, minlength=scores.shape[-1]) for row in input_ids])
-        return scores - self.freq_penalty * counts.to(scores.dtype)
+            return cast(torch.FloatTensor, scaled)
+        counts = torch.stack([torch.bincount(row, minlength=scaled.shape[-1]) for row in input_ids])
+        return cast(torch.FloatTensor, scaled - self.freq_penalty * counts.to(scaled.dtype))
 
 
 class _SequenceCollector(BaseStreamer):

--- a/apps/graph/tests/test_np_model_id_mapping.py
+++ b/apps/graph/tests/test_np_model_id_mapping.py
@@ -1,0 +1,73 @@
+"""Guard the HuggingFace -> Neuronpedia model id mapping a graph is labelled with.
+
+The dict this replaced was hand-kept and carried `meta-llama/Llama-3.2-1B -> llama3.1-8b`, a
+different model. Nothing compared it against `np_model_to_hf.json` or the webapp's own copy, so the
+wrong id reached the `scan` field of every graph such a pod produced and no test failed.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from neuronpedia_graph.model_ids import (
+    FALLBACK_HF_MODEL_ID_TO_NP_MODEL_ID,
+    _load_np_model_to_hf,
+    hf_model_id_to_np_model_id,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MAPPING_PATH = REPO_ROOT / "np_model_to_hf.json"
+
+
+def test_mapping_file_is_present_and_readable():
+    """Fail rather than skip. A silently absent file means the fallback ships as the real table."""
+    assert MAPPING_PATH.exists(), f"{MAPPING_PATH} is missing"
+    assert _load_np_model_to_hf(), "np_model_to_hf.json read as empty"
+
+
+def test_mapping_file_is_injective():
+    """One repo, one Neuronpedia model. `Model.hfRepoId` is unique in the webapp schema, so a
+    duplicate here would reverse into a table that silently drops a model."""
+    with open(MAPPING_PATH, encoding="utf-8") as f:
+        mapping = json.load(f)
+    repos = list(mapping.values())
+    duplicates = {repo for repo in repos if repos.count(repo) > 1}
+    assert not duplicates, f"repo ids mapped to more than one model: {sorted(duplicates)}"
+
+
+def test_reverse_lookup_matches_the_file():
+    forward = _load_np_model_to_hf()
+    reverse = hf_model_id_to_np_model_id()
+    assert len(reverse) == len(forward)
+    for np_id, hf_id in forward.items():
+        assert reverse[hf_id] == np_id
+
+
+@pytest.mark.parametrize(
+    ("hf_model_id", "expected_np_model_id"),
+    [
+        ("google/gemma-2-2b", "gemma-2-2b"),
+        ("google/gemma-3-4b-it", "gemma-3-4b-it"),
+        ("Qwen/Qwen3-1.7B", "qwen3-1.7b"),
+        ("Qwen/Qwen3-4B", "qwen3-4b"),
+        # Not a stripped namespace: the Neuronpedia id is a different string entirely.
+        ("openai-community/gpt2", "gpt2-small"),
+    ],
+)
+def test_known_models_resolve(hf_model_id: str, expected_np_model_id: str):
+    assert hf_model_id_to_np_model_id()[hf_model_id] == expected_np_model_id
+
+
+def test_llama_3_2_1b_is_not_mapped_to_llama_3_1_8b():
+    """The specific regression. Llama-3.2-1B is not a model Neuronpedia carries; if it is ever
+    added, it gets its own id rather than borrowing an 8B model's."""
+    assert hf_model_id_to_np_model_id().get("meta-llama/Llama-3.2-1B") != "llama3.1-8b"
+
+
+def test_fallback_entries_all_exist_in_the_mapping_file():
+    """The fallback is a copy for availability, not a second source. An entry that drifts out of
+    the file would serve a stale id on any pod whose image lacks the repo root."""
+    reverse = hf_model_id_to_np_model_id()
+    for hf_model_id, np_model_id in FALLBACK_HF_MODEL_ID_TO_NP_MODEL_ID.items():
+        assert reverse.get(hf_model_id) == np_model_id, f"{hf_model_id} disagrees with np_model_to_hf.json"

--- a/apps/graph/tests/test_steer_generation.py
+++ b/apps/graph/tests/test_steer_generation.py
@@ -36,6 +36,7 @@ def hf_model() -> GPT2LMHeadModel:
     model = GPT2LMHeadModel(config).eval()
     # An untrained model emits token ids uniformly, so it would hit EOS partway through and every
     # length below would depend on the seed. No EOS means every run reaches `max_new_tokens`.
+    assert model.generation_config is not None, "GPT2LMHeadModel should build a generation config"
     model.generation_config.eos_token_id = None
     return model
 
@@ -78,6 +79,11 @@ class FakeInterpEngineModel:
             output_logits=True,
             **kwargs,
         )
+        # `generate` returns bare ids unless `return_dict_in_generate` is set, which it is above.
+        # Asserting it rather than casting keeps the test honest: if that keyword ever stops being
+        # forwarded, this fails here instead of reading attributes off a tensor.
+        assert not isinstance(output, torch.Tensor), "expected a GenerateOutput, not bare token ids"
+        assert output.logits is not None, "output_logits=True should populate logits"
         self.sequences = output.sequences
         return "the continuation, as text", torch.cat(output.logits, dim=0), None
 

--- a/apps/webapp/app/api/admin/new-model/route.tsx
+++ b/apps/webapp/app/api/admin/new-model/route.tsx
@@ -1,12 +1,14 @@
+import { HF_REPO_ID_ERROR_MESSAGE, isValidHfRepoId } from '@/lib/utils/model';
 import { RequestAuthedAdminUser, withAuthedAdminUser } from '@/lib/with-user';
 import { NextResponse } from 'next/server';
-import { createModelAdmin } from '../../../../lib/db/model';
+import { createModelAdmin, getModelByHfRepoIdIgnoringAccess } from '../../../../lib/db/model';
 
 type ModelToCreate = {
   id: string;
   displayName: string;
   owner: string;
   layers: number;
+  hfRepoId?: string | null;
 };
 
 export const POST = withAuthedAdminUser(async (request: RequestAuthedAdminUser) => {
@@ -15,7 +17,24 @@ export const POST = withAuthedAdminUser(async (request: RequestAuthedAdminUser) 
   const modelId = body.id.toLowerCase();
   const { displayName } = body;
 
-  const model = await createModelAdmin(modelId, displayName, body.layers, body.owner, request.user);
+  // Not lowercased: repo ids are case-sensitive on the Hub (`google/gemma-4-E2B`).
+  const hfRepoId = body.hfRepoId?.trim() || null;
+  if (hfRepoId) {
+    if (!isValidHfRepoId(hfRepoId)) {
+      return NextResponse.json({ error: HF_REPO_ID_ERROR_MESSAGE }, { status: 400 });
+    }
+    // Checked here so a duplicate reads as a conflict rather than surfacing as a 500 from the
+    // unique index. Racy by nature, which is why the index exists as well.
+    const existing = await getModelByHfRepoIdIgnoringAccess(hfRepoId);
+    if (existing) {
+      return NextResponse.json(
+        { error: `HuggingFace repo ${hfRepoId} is already mapped to model ${existing.id}` },
+        { status: 409 },
+      );
+    }
+  }
+
+  const model = await createModelAdmin(modelId, displayName, body.layers, body.owner, request.user, hfRepoId);
 
   return NextResponse.json(model);
 });

--- a/apps/webapp/app/api/model/lookup/route.ts
+++ b/apps/webapp/app/api/model/lookup/route.ts
@@ -1,0 +1,115 @@
+import { getModelByHfRepoId } from '@/lib/db/model';
+import { HF_REPO_ID_ERROR_MESSAGE, MAX_HF_REPO_ID_CHARS, isValidHfRepoId } from '@/lib/utils/model';
+import { RequestOptionalUser, withOptionalUser } from '@/lib/with-user';
+import { NextResponse } from 'next/server';
+import * as yup from 'yup';
+
+/**
+ * @swagger
+ * /api/model/lookup:
+ *   post:
+ *     summary: Find the Neuronpedia model for a HuggingFace repo
+ *     description: |
+ *       Neuronpedia model ids are slash-free, so they cannot be a HuggingFace repo id and are not
+ *       derived from one by stripping the namespace (`openai-community/gpt2` is `gpt2-small` here).
+ *       This resolves one to the other. A repo maps to at most one model.
+ *     tags:
+ *       - Models
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - hfRepoId
+ *             properties:
+ *               hfRepoId:
+ *                 type: string
+ *                 description: The HuggingFace repo id, as `namespace/name`. Case-sensitive.
+ *                 example: "openai-community/gpt2"
+ *     responses:
+ *       200:
+ *         description: The model serving that repo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                   description: The Neuronpedia model id, which is also its URL segment
+ *                   example: "gpt2-small"
+ *                 hfRepoId:
+ *                   type: string
+ *                 displayName:
+ *                   type: string
+ *                 displayNameShort:
+ *                   type: string
+ *                 layers:
+ *                   type: integer
+ *                 neuronsPerLayer:
+ *                   type: integer
+ *                 dimension:
+ *                   type: integer
+ *                   nullable: true
+ *                 instruct:
+ *                   type: boolean
+ *                 thinking:
+ *                   type: boolean
+ *                 inferenceEnabled:
+ *                   type: boolean
+ *                 website:
+ *                   type: string
+ *                   nullable: true
+ *       400:
+ *         description: Bad request - hfRepoId missing or malformed
+ *       404:
+ *         description: No model on Neuronpedia corresponds to that repo
+ */
+
+const LookupRequestSchema = yup.object({
+  hfRepoId: yup
+    .string()
+    .required()
+    .max(MAX_HF_REPO_ID_CHARS)
+    .test('hf-repo-id', HF_REPO_ID_ERROR_MESSAGE, (value) => !value || isValidHfRepoId(value)),
+});
+
+export const POST = withOptionalUser(async (request: RequestOptionalUser) => {
+  let validatedRequest;
+  try {
+    validatedRequest = await LookupRequestSchema.validate(await request.json());
+  } catch (error) {
+    if (error instanceof yup.ValidationError) {
+      return NextResponse.json({ error: error.message, path: error.path }, { status: 400 });
+    }
+    throw error;
+  }
+
+  const model = await getModelByHfRepoId(validatedRequest.hfRepoId, request.user);
+  if (!model) {
+    return NextResponse.json(
+      { error: `No Neuronpedia model for HuggingFace repo ${validatedRequest.hfRepoId}` },
+      { status: 404 },
+    );
+  }
+
+  // Mapped field by field rather than returned whole. This is a public route, so its shape is a
+  // contract: a column added to `Model` must not appear here by accident. `tlensId` and
+  // `openRouterId` are withheld deliberately -- the first is an internal spelling being retired,
+  // the second an upstream provider id, as `/api/nla/sources` also withholds it.
+  return NextResponse.json({
+    id: model.id,
+    hfRepoId: model.hfRepoId,
+    displayName: model.displayName,
+    displayNameShort: model.displayNameShort,
+    layers: model.layers,
+    neuronsPerLayer: model.neuronsPerLayer,
+    dimension: model.dimension,
+    instruct: model.instruct,
+    thinking: model.thinking,
+    inferenceEnabled: model.inferenceEnabled,
+    website: model.website,
+  });
+});

--- a/apps/webapp/app/api/model/new/route.tsx
+++ b/apps/webapp/app/api/model/new/route.tsx
@@ -1,4 +1,5 @@
-import { createModel, getModelById } from '@/lib/db/model';
+import { createModel, getModelByHfRepoIdIgnoringAccess, getModelById } from '@/lib/db/model';
+import { HF_REPO_ID_ERROR_MESSAGE, MAX_HF_REPO_ID_CHARS, isValidHfRepoId } from '@/lib/utils/model';
 import { RequestAuthedUser, withAuthedUser } from '@/lib/with-user';
 import { Visibility } from '@prisma/client';
 import { NextResponse } from 'next/server';
@@ -50,6 +51,12 @@ import * as yup from 'yup';
  *                 nullable: true
  *                 description: Optional URL for the model's website or documentation
  *                 example: "https://huggingface.co/gpt2"
+ *               hfRepoId:
+ *                 type: string
+ *                 nullable: true
+ *                 pattern: '^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$'
+ *                 description: The HuggingFace repo this model corresponds to, as `namespace/name`. Case-sensitive, and unique across models. Omit it for a model that is not on the Hub.
+ *                 example: "openai-community/gpt2"
  *     responses:
  *       200:
  *         description: Model created successfully
@@ -79,6 +86,8 @@ import * as yup from 'yup';
  *                   description: Field path that caused the validation error (if applicable)
  *       401:
  *         description: Unauthorized - authentication required
+ *       409:
+ *         description: Conflict - the given hfRepoId is already mapped to another model
  *       500:
  *         description: Internal server error
  */
@@ -98,6 +107,13 @@ const NewModelRequestSchema = yup.object({
   layers: yup.number().required().integer().min(1).max(127, 'Layers must be an integer less than 128'),
   displayName: yup.string().optional().min(1).max(64, 'Display name must be less than 64 characters'),
   url: yup.string().optional().nullable().url('Must be a valid URL'),
+  // Not lowercased, unlike `id`: repo ids are case-sensitive on the Hub (`google/gemma-4-E2B`).
+  hfRepoId: yup
+    .string()
+    .optional()
+    .nullable()
+    .max(MAX_HF_REPO_ID_CHARS)
+    .test('hf-repo-id', HF_REPO_ID_ERROR_MESSAGE, (value) => !value || isValidHfRepoId(value)),
 });
 
 export const POST = withAuthedUser(async (request: RequestAuthedUser) => {
@@ -119,6 +135,19 @@ export const POST = withAuthedUser(async (request: RequestAuthedUser) => {
     return NextResponse.json({ error: 'Model already exists' }, { status: 400 });
   }
 
+  const hfRepoId = validatedRequest.hfRepoId?.trim() || null;
+  if (hfRepoId) {
+    // Checked here so a duplicate reads as a conflict rather than surfacing as a 500 from the
+    // unique index. Racy by nature, which is why the index exists as well.
+    const modelWithRepo = await getModelByHfRepoIdIgnoringAccess(hfRepoId);
+    if (modelWithRepo) {
+      return NextResponse.json(
+        { error: `HuggingFace repo ${hfRepoId} is already mapped to model ${modelWithRepo.id}` },
+        { status: 409 },
+      );
+    }
+  }
+
   const model = {
     id: validatedRequest.id,
     creatorId: request.user.id,
@@ -130,6 +159,7 @@ export const POST = withAuthedUser(async (request: RequestAuthedUser) => {
     instruct: false,
     tlensId: null,
     openRouterId: null,
+    hfRepoId,
     inferenceEnabled: false,
     dimension: null,
     defaultSourceId: null,

--- a/apps/webapp/lib/db/model.ts
+++ b/apps/webapp/lib/db/model.ts
@@ -60,6 +60,25 @@ export const getModelById = async (modelId: string, user?: AuthenticatedUser | n
   return model;
 };
 
+// The reverse of the model id in the URL: given what HuggingFace calls a model, find ours.
+//
+// `findFirst` rather than `findUnique` because the access clause is an extra condition, which
+// `findUnique` does not accept. `hfRepoId` is unique in the schema, so this is still at most one
+// row -- a caller who cannot see it gets null, the same as an unknown repo.
+export const getModelByHfRepoId = async (hfRepoId: string, user?: AuthenticatedUser | null) =>
+  prisma.model.findFirst({
+    where: {
+      hfRepoId,
+      ...userCanAccessClause(user, AllowUnlistedFor.EVERYONE),
+    },
+  });
+
+// Whichever model claims this repo, visibility ignored. For deciding whether a write would collide
+// with the unique index, never for serving to a user: a PRIVATE model still occupies the repo id,
+// and `getModelByHfRepoId` would not see it.
+export const getModelByHfRepoIdIgnoringAccess = async (hfRepoId: string) =>
+  prisma.model.findUnique({ where: { hfRepoId } });
+
 // sometimes transformerlens model IDs do not match our model IDs, so we need to replace them
 export const getTransformerLensModelIdIfExists = async (modelId: string) => {
   const model = await getModelById(modelId);
@@ -112,6 +131,7 @@ export const createModelAdmin = async (
   layers: number,
   owner: string,
   user: AuthenticatedUser,
+  hfRepoId?: string | null,
 ) =>
   prisma.model.create({
     data: {
@@ -123,5 +143,6 @@ export const createModelAdmin = async (
       layers,
       neuronsPerLayer: 0,
       owner,
+      hfRepoId: hfRepoId ?? null,
     },
   });

--- a/apps/webapp/lib/utils/model.test.ts
+++ b/apps/webapp/lib/utils/model.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_HF_REPO_ID_CHARS, isValidHfRepoId } from './model';
+
+// Every value the migration backfills, so the validator cannot reject something already in the
+// column. Taken from np_model_to_hf.json, including the awkward ones.
+const BACKFILLED_REPO_IDS = [
+  'EleutherAI/pythia-70m-deduped',
+  'openai-community/gpt2',
+  'google/gemma-3-1b-pt',
+  'Qwen/Qwen3.5-0.8B',
+  'Qwen/Qwen2.5-1.5B-Instruct',
+  'google/gemma-4-E2B',
+  'meta-llama/Llama-3.3-70B-Instruct',
+  'meta-models/Muse-Glimmer-30B',
+  'allenai/Olmo-3-1025-7B',
+  'deepseek-ai/DeepSeek-R1-Distill-Llama-8B',
+];
+
+describe('isValidHfRepoId', () => {
+  it.each(BACKFILLED_REPO_IDS)('accepts %s', (repoId) => {
+    expect(isValidHfRepoId(repoId)).toBe(true);
+  });
+
+  it('accepts a repo id whose name carries dots, underscores and dashes', () => {
+    expect(isValidHfRepoId('org/Some_model.v2-final')).toBe(true);
+  });
+
+  it('rejects a bare name, which the Hub resolves but we do not store', () => {
+    expect(isValidHfRepoId('gpt2')).toBe(false);
+  });
+
+  it('rejects a Neuronpedia model id, which is the whole point of requiring the slash', () => {
+    expect(isValidHfRepoId('gpt2-small')).toBe(false);
+    expect(isValidHfRepoId('gemma-2-2b-it')).toBe(false);
+  });
+
+  it('rejects more than one slash', () => {
+    expect(isValidHfRepoId('org/repo/extra')).toBe(false);
+  });
+
+  it('rejects an empty half', () => {
+    expect(isValidHfRepoId('/repo')).toBe(false);
+    expect(isValidHfRepoId('org/')).toBe(false);
+    expect(isValidHfRepoId('/')).toBe(false);
+  });
+
+  it('rejects a component that is a relative path, since this value reaches URL building', () => {
+    expect(isValidHfRepoId('../secrets')).toBe(false);
+    expect(isValidHfRepoId('org/..')).toBe(false);
+    expect(isValidHfRepoId('../..')).toBe(false);
+  });
+
+  it('rejects query and fragment characters that would redirect a fetch', () => {
+    expect(isValidHfRepoId('org/repo?x=1')).toBe(false);
+    expect(isValidHfRepoId('org/repo#main')).toBe(false);
+    expect(isValidHfRepoId('org/repo with space')).toBe(false);
+  });
+
+  it('rejects a component starting with punctuation', () => {
+    expect(isValidHfRepoId('.org/repo')).toBe(false);
+    expect(isValidHfRepoId('org/-repo')).toBe(false);
+  });
+
+  it('rejects a value longer than the Hub allows', () => {
+    const half = 'a'.repeat(MAX_HF_REPO_ID_CHARS);
+    expect(isValidHfRepoId(`${half}/${half}`)).toBe(false);
+  });
+
+  it('is case-preserving rather than case-insensitive, so both spellings validate', () => {
+    // The column stores what the Hub calls it. `gemma-4-E2B` and `gemma-4-e2b` are different repos
+    // as far as this validator is concerned, and the unique index treats them as different rows.
+    expect(isValidHfRepoId('google/gemma-4-E2B')).toBe(true);
+    expect(isValidHfRepoId('google/gemma-4-e2b')).toBe(true);
+  });
+});

--- a/apps/webapp/lib/utils/model.ts
+++ b/apps/webapp/lib/utils/model.ts
@@ -1,0 +1,27 @@
+// A HuggingFace repo id, as stored in `Model.hfRepoId`.
+//
+// Exactly one slash is required, so `gpt2` is rejected even though the Hub still resolves it as a
+// legacy canonical repo. That is the point rather than an oversight: a slash is what tells a
+// Neuronpedia model id apart from a HuggingFace one, here and in the SQL that audits the column.
+// A bare name would be ambiguous with our own ids, and the canonical spelling exists anyway
+// (`openai-community/gpt2`).
+//
+// Each half must begin with a letter or digit, which is also what stops a component being `..`
+// -- this value reaches URL building in `lib/utils/saelens.ts`, with our HF_TOKEN attached.
+export const HF_REPO_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+// The Hub's own limit per component. Two of those plus the separator.
+export const MAX_HF_REPO_ID_CHARS = 193;
+
+export const HF_REPO_ID_ERROR_MESSAGE =
+  "HuggingFace repo id must be `namespace/name`, using only letters, digits, '.', '_' and '-'";
+
+/**
+ * Report whether a string is a well-formed HuggingFace repo id.
+ *
+ * Case is preserved by every caller. Unlike `Model.id`, which is lowercased on the way in, a repo
+ * id is case-sensitive on the Hub -- `google/gemma-4-E2B` is not `google/gemma-4-e2b`.
+ */
+export function isValidHfRepoId(value: string): boolean {
+  return value.length <= MAX_HF_REPO_ID_CHARS && HF_REPO_ID_REGEX.test(value);
+}

--- a/apps/webapp/prisma/generated/zod/index.ts
+++ b/apps/webapp/prisma/generated/zod/index.ts
@@ -80,7 +80,7 @@ export const ListsOnActivationsScalarFieldEnumSchema = z.enum(['activationId','l
 
 export const VerificationTokenScalarFieldEnumSchema = z.enum(['identifier','token','expires']);
 
-export const ModelScalarFieldEnumSchema = z.enum(['id','displayNameShort','displayName','creatorId','tlensId','openRouterId','dimension','thinking','visibility','defaultSourceSetName','defaultSourceId','defaultGraphSourceSetName','inferenceEnabled','instruct','layers','neuronsPerLayer','createdAt','owner','updatedAt','website']);
+export const ModelScalarFieldEnumSchema = z.enum(['id','displayNameShort','displayName','creatorId','tlensId','openRouterId','hfRepoId','dimension','thinking','visibility','defaultSourceSetName','defaultSourceId','defaultGraphSourceSetName','inferenceEnabled','instruct','layers','neuronsPerLayer','createdAt','owner','updatedAt','website']);
 
 export const ModelHeadMetricsScalarFieldEnumSchema = z.enum(['id','modelId','layer','headIndex','modelName','datasetName','nSequences','seqLen','dtype','attnImplementation','selfAttentionScore','prevTokenScore','patternEntropy','qkDistance','qkDistanceVariance','inductionScore','qkDistanceHistogram','topQueryTokens','topKeyTokens','activationHistogram','headStatistics','createdAt','updatedAt']);
 
@@ -1264,6 +1264,7 @@ export const ModelSchema = z.object({
   creatorId: z.string(),
   tlensId: z.string().nullable(),
   openRouterId: z.string().nullable(),
+  hfRepoId: z.string().nullable(),
   dimension: z.number().int().nullable(),
   thinking: z.boolean(),
   defaultSourceSetName: z.string().nullable(),

--- a/apps/webapp/prisma/migrations/20260904235608_add_model_hf_repo_id/migration.sql
+++ b/apps/webapp/prisma/migrations/20260904235608_add_model_hf_repo_id/migration.sql
@@ -1,0 +1,54 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[hfRepoId]` on the table `Model` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Model" ADD COLUMN     "hfRepoId" TEXT;
+
+UPDATE "Model" SET "hfRepoId" = 'EleutherAI/pythia-70m-deduped' WHERE id = 'pythia-70m-deduped';
+UPDATE "Model" SET "hfRepoId" = 'openai-community/gpt2' WHERE id = 'gpt2-small';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-270m' WHERE id = 'gemma-3-270m';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-270m-it' WHERE id = 'gemma-3-270m-it';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3.5-0.8B' WHERE id = 'qwen3.5-0.8b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-1b-pt' WHERE id = 'gemma-3-1b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-1b-it' WHERE id = 'gemma-3-1b-it';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen2.5-1.5B-Instruct' WHERE id = 'qwen2.5-1.5b-it';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3-1.7B' WHERE id = 'qwen3-1.7b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-2-2b' WHERE id = 'gemma-2-2b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-2-2b-it' WHERE id = 'gemma-2-2b-it';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-4-E2B' WHERE id = 'gemma-4-e2b';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3.5-2B-Base' WHERE id = 'qwen3.5-2b-pt';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-4b-pt' WHERE id = 'gemma-3-4b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-4b-it' WHERE id = 'gemma-3-4b-it';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-4-E4B' WHERE id = 'gemma-4-e4b';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3-4B' WHERE id = 'qwen3-4b';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3.5-4B' WHERE id = 'qwen3.5-4b';
+UPDATE "Model" SET "hfRepoId" = 'allenai/Olmo-3-1025-7B' WHERE id = 'olmo-3-1025-7b';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen2.5-7B-Instruct' WHERE id = 'qwen2.5-7b-it';
+UPDATE "Model" SET "hfRepoId" = 'meta-llama/Llama-3.1-8B' WHERE id = 'llama3.1-8b';
+UPDATE "Model" SET "hfRepoId" = 'meta-llama/Llama-3.1-8B-Instruct' WHERE id = 'llama3.1-8b-it';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3-8B' WHERE id = 'qwen3-8b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-2-9b' WHERE id = 'gemma-2-9b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-2-9b-it' WHERE id = 'gemma-2-9b-it';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3.5-9B-Base' WHERE id = 'qwen3.5-9b-pt';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-12b-pt' WHERE id = 'gemma-3-12b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-12b-it' WHERE id = 'gemma-3-12b-it';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3-14B' WHERE id = 'qwen3-14b';
+UPDATE "Model" SET "hfRepoId" = 'openai/gpt-oss-20b' WHERE id = 'gpt-oss-20b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-2-27b' WHERE id = 'gemma-2-27b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-27b-pt' WHERE id = 'gemma-3-27b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-3-27b-it' WHERE id = 'gemma-3-27b-it';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3.5-27B' WHERE id = 'qwen3.5-27b';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3.6-27B' WHERE id = 'qwen3.6-27b';
+UPDATE "Model" SET "hfRepoId" = 'meta-models/Muse-Glimmer-30B' WHERE id = 'glimmer-30b';
+UPDATE "Model" SET "hfRepoId" = 'google/gemma-4-31B' WHERE id = 'gemma-4-31b';
+UPDATE "Model" SET "hfRepoId" = 'allenai/Olmo-3-1125-32B' WHERE id = 'olmo-3-1125-32b';
+UPDATE "Model" SET "hfRepoId" = 'Qwen/Qwen3-32B' WHERE id = 'qwen3-32b';
+UPDATE "Model" SET "hfRepoId" = 'meta-llama/Llama-3.3-70B-Instruct' WHERE id = 'llama3.3-70b-it';
+UPDATE "Model" SET "hfRepoId" = 'deepseek-ai/DeepSeek-V4-Flash' WHERE id = 'deepseek-v4-flash';
+UPDATE "Model" SET "hfRepoId" = 'deepseek-ai/DeepSeek-R1-Distill-Llama-8B' WHERE id = 'deepseek-r1-distill-llama-8b';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Model_hfRepoId_key" ON "Model"("hfRepoId");

--- a/apps/webapp/prisma/schema.prisma
+++ b/apps/webapp/prisma/schema.prisma
@@ -369,6 +369,16 @@ model Model {
 
   tlensId      String?
   openRouterId String?
+  // The HuggingFace repo id this model corresponds to, when it has one. Null is a real answer, not
+  // a gap to backfill: a model supplied locally is not on the Hub, and still gets a Neuronpedia id,
+  // a URL and sources like any other row. Postgres does not collide nulls in a unique index, so any
+  // number of rows may be null while every non-null value stays distinct.
+  //
+  // Unique, so a repo id resolves to one model and the lookup by it can return a single row. Note
+  // this is a rule about what a model row *is*, not one about weights: a row names the weights it
+  // serves, so a variant that runs a different repo's weights against these SAEs is its own row
+  // with its own repo id, and never a second row pointing here.
+  hfRepoId     String? @unique
   dimension    Int?
   thinking     Boolean @default(false)
 


### PR DESCRIPTION
Neuronpedia model ids are slash-free and are not derived from HuggingFace ones — `openai-community/gpt2` is `gpt2-small` here, `google/gemma-3-4b-pt` is `gemma-3-4b`. Nothing in the database recorded that relationship, so it lived in five hand-maintained copies that no test compared: `np_model_to_hf.json`, `GRAPH_MODEL_MAP`, graph's `HF_MODEL_ID_TO_NP_MODEL_ID`, the `neuronpedia.model_id` block per `pods.yaml` entry, and the test harness.

One of them was wrong, and shipped wrong data. This adds the column that answers the question once, and removes the copy that was incorrect.

## A live bug, fixed

`HF_MODEL_ID_TO_NP_MODEL_ID` mapped `meta-llama/Llama-3.2-1B` to `llama3.1-8b` — a different model — and that value is read unguarded to fill a stored graph's `scan` field. Nothing compared it against anything, so it failed no test. The entry is in no `pods.yaml` config, so nothing was running it, and Neuronpedia carries no Llama-3.2-1B model; it is removed rather than repointed.

Two things found alongside it:

- `Qwen/Qwen3-1.7B` was missing from the map while `crm_backend` defaults `NP_MODEL_ID` to `qwen3-1.7b`, so that model was a second latent `KeyError`.
- An unlisted `MODEL_ID` used to raise a `KeyError` inside `build_model` — *after* attribution finished. Minutes of GPU time on a pod that was never going to return a graph. It now fails in the lifespan.

## `Model.hfRepoId`

Unique, so a repo resolves to a single model. Nullable, because a locally supplied model is not on the Hub and null is a real answer rather than a gap — Postgres does not collide nulls in a unique index.

The migration backfills 41 rows from `np_model_to_hf.json` plus `deepseek-r1-distill-llama-8b`, which the file never covered. That one is worth reading: its pod runs `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` (`CUSTOM_HF_MODEL_ID`) against SAEs trained on `meta-llama/Llama-3.1-8B` (`MODEL_ID`), and `hfRepoId` is the former. Recording the latter would claim the distill *is* `llama3.1-8b`, which the unique index now rejects. The index is ordered after the backfill so a collision fails on it rather than leaving half the rows written.

Both creation routes now accept an optional `hfRepoId`, so the column cannot start rotting the day it ships — without that, every model created from here on would be absent from any mapping file generated from the database. Neither route lowercases it, since repo ids are case-sensitive on the Hub (`google/gemma-4-E2B`).

`POST /api/model/lookup` is the reverse direction, for callers holding a HuggingFace id. It maps the response field by field rather than returning the row, since `/api/*` field names are a contract.

## Production impact

Checked against production before opening this:

| | |
| --- | --- |
| Migrations pending | 1 — this one |
| `Model` rows | 78 |
| Rows the backfill fills | 41 |
| `UPDATE`s matching nothing | 1 (`glimmer-30b`, absent from prod — a no-op) |
| Collision risk | none; all 41 values are distinct |

37 rows are left null. Most are test and legacy models (`test-model-123`, `myopmodel`, nine `pup-xl*` variants); a handful are real models simply missing from the mapping file (`gemma-2b`, `gemma-7b`, `gpt2-xl`, `mistral-7b`, `pythia-160m-deduped`). Null is legitimate for anything not on the Hub, so this is a list to triage, not to clear.

Since `npm run build` is `prisma generate && prisma migrate deploy && next build`, merging applies the migration. A migration failure fails the build rather than shipping a broken app — but note that a failed `_prisma_migrations` row blocks later deploys until someone runs `prisma migrate resolve --rolled-back`.

## Also in here

The third commit clears four pre-existing pyright errors in `steer_generation.py` and its test. Unrelated to the rest — they surfaced because pyright runs over the whole package once any file in it is touched, and graph is one of the three apps whose pyright job does not gate CI. No `type: ignore`; the test fixes narrow with asserts rather than casts, so a dropped `return_dict_in_generate` fails at the assert instead of reading attributes off a tensor.

## Not in here

Three copies of the mapping remain, deliberately, as follow-ups: generating `np_model_to_hf.json` from the database, deleting `GRAPH_MODEL_MAP`, and having `new_pod.py` verify `pods.yaml`. Retiring `tlensId` — which turns out to already hold a HuggingFace repo id for at least some rows — is the last step and touches live inference traffic, so it wants its own change.

Worth knowing separately: production has a model row whose id is `Qwen/Qwen3.5-27B`. A Neuronpedia id containing a slash cannot work as a URL segment; it got in because `/api/admin/new-model` does not validate ids at all.

## Checks

- webapp: `npm run lint` (eslint + `tsc --noEmit`), `format:check`, 124 tests
- graph: `ruff check`, `ruff format --check`, `pyright` at **0 errors**, 76 tests
- Unique index behaviour verified against the real index in a rolled-back transaction: two nulls coexist, `google/gemma-4-E2B` and `google/gemma-4-e2b` are distinct keys, and a duplicate is rejected.
